### PR TITLE
Pass along isEvent property when cloning a signal

### DIFF
--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -654,6 +654,7 @@ export class Signal implements IDataSequence {
 		out.targetSpace = this.targetSpace;
 		out.frameRate = this.frameRate;
 		out.cycles = this.cycles;
+		out.isEvent = this.isEvent;
 
 		if (this._resultType) {
 			out.resultType = this._resultType;


### PR DESCRIPTION
Fixes an issue where the isEvent property is lost when cloning a signal which causes unexpected results in the `eventMask` step.