### PR TITLE
Vector step: add support for providing a single input

### DIFF
--- a/docs/nodes/steps/data-structure.md
+++ b/docs/nodes/steps/data-structure.md
@@ -47,8 +47,9 @@ output. This will be done on each component, if they exist.
 
 > **Inputs**
 >
-> 1. `Scalar | Series | Number`
-> 2. `Scalar | Series | Number`
+> 1. `Scalar | Series | Number | Series (<vector> | <segment> | <plane>)`
+> 2. `Scalar | Series | Number` (optional)
+> 3. `Scalar | Series | Number` (optional)
 >
 > **Output:** `Scalar | Series | Number`
 
@@ -69,9 +70,16 @@ output. This will be done on each component, if they exist.
 >
 
 
-The `vector` step takes three inputs and outputs a vector 
-sequence signal, where the three inputs will be assigned to 
-the `x`, `y`, and `z` components, respectively.
+The `vector` step takes one or three inputs and outputs a 
+vector sequence signal. 
+
+If given three numeric or 1-dimensional series inputs, each 
+input will be assigned to the `x`, `y`, and `z` components, 
+respectively.
+
+Alternatively, if only one input is given and it contains at
+least three components, the first three components will be 
+used to construct the vector sequence.
 
 If the inputs have different lengths, the output signal will 
 be the length of the longest input and shorter inputs will be 

--- a/src/lib/processing/vector.spec.ts
+++ b/src/lib/processing/vector.spec.ts
@@ -20,7 +20,7 @@ test('VectorStep - Input errors', async (t) => {
 	// No input
 	await t.throwsAsync(mockStep(VectorStep).process());
 
-	// One input
+	// One input (wrong type)
 	await t.throwsAsync(mockStep(VectorStep, [s1]).process());
 
 	// Two inputs
@@ -36,7 +36,7 @@ test('VectorStep - Input errors', async (t) => {
 	await t.throwsAsync(mockStep(VectorStep, [segment1, s2, s4]).process());
 });
 
-test('VectorStep - arrays of same length', async (t) => {
+test('VectorStep - three inputs, arrays of same length', async (t) => {
 	const step = mockStep(VectorStep, [s1, s2, s3]);
 
 	const res = await step.process();
@@ -45,7 +45,7 @@ test('VectorStep - arrays of same length', async (t) => {
 	t.deepEqual(res.array, [f32(1, 2, 3), f32(4, 5, 6), f32(7, 8, 9)]);
 });
 
-test('VectorStep - number inputs', async (t) => {
+test('VectorStep - three inputs, number', async (t) => {
 	const step = mockStep(VectorStep, [new Signal(1), new Signal(2), new Signal(3)]);
 
 	const res = await step.process();
@@ -54,11 +54,29 @@ test('VectorStep - number inputs', async (t) => {
 	t.deepEqual(res.array, [f32(1), f32(2), f32(3)]);
 });
 
-test('VectorStep - varying length inputs', async (t) => {
+test('VectorStep - three inputs, varying length', async (t) => {
 	const step = mockStep(VectorStep, [new Signal(1), s2, new Signal(f32(7, 8))]);
 
 	const res = await step.process();
 	t.is(res.length, 3);
 	t.is(res.type, SignalType.VectorSequence);
 	t.deepEqual(res.array, [f32(1, NaN, NaN), s2.getFloat32ArrayValue(), f32(7, 8, NaN)]);
+});
+
+test('VectorStep - one input, segment sequence', async (t) => {
+	const step = mockStep(VectorStep, [segment1]);
+
+	const res = await step.process();
+	t.is(res.length, 3);
+	t.is(res.type, SignalType.VectorSequence);
+	t.deepEqual(res.getValue(), vs1.getValue());
+});
+
+test('VectorStep - one input, vector sequence', async (t) => {
+	const step = mockStep(VectorStep, [vs1]);
+
+	const res = await step.process();
+	t.is(res.length, 3);
+	t.is(res.type, SignalType.VectorSequence);
+	t.deepEqual(res.getValue(), vs1.getValue());
 });


### PR DESCRIPTION
Adds the ability for the `vector` step to use the three first components of a single input to map to the x, y, and z components of its output.

This enables the use of, e.g., a segment as the input and the output will be the positional vector of the segment.