### PR TITLE
Filter step: Allow signals with all NaNs, give warning instead of error

### DIFF
--- a/src/lib/processing/algorithms/filter.spec.ts
+++ b/src/lib/processing/algorithms/filter.spec.ts
@@ -111,5 +111,10 @@ test('LowPassFilterStep - all NaNs', async (t) => {
 	const series = new Signal(f32(undefined, undefined, undefined, undefined, undefined, undefined), 300);
 	const step = mockStep(LowPassFilterStep, [series], { extrapolate: 2, cutoff: 15, iterations: 2, order: 1 });
 
-	await t.throwsAsync(step.process());
+	const res = await step.process();
+
+	t.deepEqual(res.getValue(), series.getValue());
+
+	// Expect a warning.
+	t.is(step.processingWarnings.length, 1);
 });

--- a/src/lib/processing/algorithms/filter.ts
+++ b/src/lib/processing/algorithms/filter.ts
@@ -2,7 +2,7 @@ import * as Fili from 'fili/dist/fili.min.js';
 
 import { PropertyType } from '../../models/property';
 import { StepCategory, StepClass } from '../../step-registry';
-import { ProcessingError } from '../../utils/processing-error';
+import { NumberUtil } from '../../utils/number';
 import { SeriesBufferMethod, SeriesUtil } from '../../utils/series';
 import { markdownFmt } from '../../utils/template-literal-tags';
 
@@ -88,8 +88,12 @@ export class BaseFilterStep extends BaseAlgorithmStep {
 
 		this.filter = new Fili.IirFilter(filterCoeffs);
 	}
-	function(a: TypedArray): TypedArray {
-		if (a.every(v => isNaN(v))) throw new ProcessingError('The input signal is all NaN.');
+
+	function(a: TypedArray, index: number): TypedArray {
+		if (a.every(v => isNaN(v))) {
+			this.processingWarnings.push(`All values are NaN (on ${ NumberUtil.formatOrdinal(index + 1) } component).`);
+			return a;
+		};
 
 		// Replace NaNs with 0
 		let fixedSeries = SeriesUtil.filterNaN(a, 0);

--- a/src/lib/utils/number.spec.ts
+++ b/src/lib/utils/number.spec.ts
@@ -21,3 +21,16 @@ test('NumberUtil - toPrecision', (t) => {
 	t.is(NumberUtil.toPrecision(123.12345678, undefined), 123.12345678);
 	t.is(NumberUtil.toPrecision(123.12345678, -1), 123.12345678);
 });
+
+test('NumberUtil - formatOrdinal', (t) => {
+	t.is(NumberUtil.formatOrdinal(0), '0th');
+	t.is(NumberUtil.formatOrdinal(1), '1st');
+	t.is(NumberUtil.formatOrdinal(2), '2nd');
+	t.is(NumberUtil.formatOrdinal(3), '3rd');
+	t.is(NumberUtil.formatOrdinal(4), '4th');
+	t.is(NumberUtil.formatOrdinal(5), '5th');
+	t.is(NumberUtil.formatOrdinal(15), '15th');
+	t.is(NumberUtil.formatOrdinal(21), '21st');
+	t.is(NumberUtil.formatOrdinal(121), '121st');
+	t.is(NumberUtil.formatOrdinal(1022), '1022nd');
+});

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -36,4 +36,26 @@ export class NumberUtil {
 	static isNumeric(n) {
 		return !isNaN(parseFloat(n)) && isFinite(n);
 	}
+
+	/**
+	 * Returns a string with the ordinal suffix, i.e., 
+	 * 1 => 1st
+	 * 2 => 2nd
+	 * 3 => 3rd
+	 * @param value
+	 * @returns 
+	 */
+	static formatOrdinal(value: number) {
+		const pluralRulesEn = new Intl.PluralRules("en", {type: "ordinal"});
+		const suffixes = {
+			one: 'st',
+			two: 'nd',
+			few: 'rd',
+			other: 'th',
+		};
+
+		const category = pluralRulesEn.select(value);
+		const suffix = suffixes[category];
+		return (value + suffix);
+	}
 }


### PR DESCRIPTION
Gives warning when a component of a signal is all NaNs instead of breaking the processing by throwing an error.