### PR TITLE
Arithmetic step: differing input lengths

### DIFF
--- a/docs/nodes/steps/arithmetic.md
+++ b/docs/nodes/steps/arithmetic.md
@@ -12,6 +12,14 @@ arithmetic function over them and outputs the result.
 The type of the result is of the same type as the first operand, 
 or a vector sequence if the result is an array with three elements.
 
+If one of the operands is a single number, the operand will be used
+for applying the operation for each component or array value of the 
+other input. 
+
+If both operands are arrays or component-based (marker/vector/segment)
+but with different length or with different number of components, an 
+error will be thrown as there is no defined way to apply the operation.	
+
 ## Examples
 
 ``` yaml
@@ -51,11 +59,18 @@ _Divides every component of the `Hips` segment, for all
 frames with 2._
 
 ``` yaml
+- multiply: [Hips, [1, 0, 1, 1, 1, 1, 1]]
+```
+_Multiplies the components of the `Hips` segment (`x`, `y`, 
+`z`, `rx`, `ry`, `rz`, `rw`) for all frames with the 
+corresponding item from the second operand._
+
+``` yaml
 - multiply: [Hips, [1, 0, 1]]
 ```
-_Multiplies the `x`, `y`, and `z` components of the `Hips` 
-segment, for all frames with the corresponding item from the 
-second operand._
+_Throws an error since the second operand does not cover all components
+of the first input (the first input is a segment and has 7 components;
+`x`, `y`, `z`, `rx`, `ry`, `rz`, `rw`)._
 
 ## Shared options
 

--- a/src/lib/models/segment.spec.ts
+++ b/src/lib/models/segment.spec.ts
@@ -52,6 +52,27 @@ test('Segment - fromArray', (t) => {
 	});
 });
 
+test('Segment - array', (t) => {
+	const segment = new Segment(
+		'test',
+		new VectorSequence(fakeArray, fakeArray, fakeArray, 300),
+		new QuaternionSequence(fakeArray, fakeArray, fakeArray, fakeArray),
+		300
+	);
+
+	t.deepEqual(segment.array, [
+		fakeArray,
+		fakeArray,
+		fakeArray,
+		fakeArray,
+		fakeArray,
+		fakeArray,
+		fakeArray,
+	]);
+
+	t.is(segment.array.length, 7);
+});
+
 test('Segment - getComponent', (t) => {
 	const segment = new Segment(
 		'test',

--- a/src/lib/models/sequence/matrix-sequence.spec.ts
+++ b/src/lib/models/sequence/matrix-sequence.spec.ts
@@ -16,7 +16,6 @@ const mSeq = new MatrixSequence(
 );
 
 test('MatrixSequence - constructor', (t) => {
-	console.log(mSeq);
 	t.is(mSeq.m00, fakeArray);
 	t.is(mSeq.m01, fakeArray);
 	t.is(mSeq.m02, fakeArray);

--- a/src/lib/processing/arithmetic.spec.ts
+++ b/src/lib/processing/arithmetic.spec.ts
@@ -13,6 +13,7 @@ const s2 = new Signal(f32(4, 5, 6));
 
 const frameSignal1 = new Signal(f32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).getFrames(i32(1, 4, 6, 8));
 const frameSignal2 = new Signal(f32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).getFrames(i32(2, 5, 9));
+const frameSignal3 = new Signal(f32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)).getFrames(i32(4, 6, 10));
 
 const segment1 = new Signal(new Segment('test 1', new VectorSequence(f32(1, 2, 3), f32(1, 2, 3), f32(1, 2, 3)), new QuaternionSequence(f32(1, 2, 3), f32(1, 2, 3), f32(1, 2, 3), f32(1, 2, 3))));
 const vs1 = new Signal(new VectorSequence(f32(1, 2, 3), f32(1, 2, 3), f32(1, 2, 3)));
@@ -26,6 +27,16 @@ test('Arithmetic - Input errors', async (t) => {
 
 	const step3 = mockStep(AdditionStep, [s1, undefined, s2]);
 	await t.throwsAsync(step3.process());
+
+	// Differing component count
+	const step4 = mockStep(AdditionStep, [vs1, segment1]);
+	await t.throwsAsync(step4.process());
+
+	const step5 = mockStep(AdditionStep, [new Signal([1, 2, 3]), new Signal([1, 2])]);
+	await t.throwsAsync(step5.process());
+
+	const step6 = mockStep(AdditionStep, [segment1, s1]);
+	await t.throwsAsync(step6.process());
 });
 
 test('Arithmetic - AdditionStep', async (t) => {
@@ -114,14 +125,22 @@ test('Arithmetic - Sequence order: forward', async (t) => {
 	t.deepEqual(res.getValue(), f32(3, 9, 15));
 });
 
-test('Arithmetic - Sequence order: none', async (t) => {
+test('Arithmetic - Sequence order: none, differing lengths', async (t) => {
 	const step = mockStep(AdditionStep, [frameSignal1, frameSignal2], {
+		frameSequenceOrder: FrameSequenceOperandOrder.None
+	});
+
+	await t.throwsAsync(step.process());
+});
+
+test('Arithmetic - Sequence order: none, same length', async (t) => {
+	const step = mockStep(AdditionStep, [frameSignal2, frameSignal3], {
 		frameSequenceOrder: FrameSequenceOperandOrder.None
 	});
 
 	const res = await step.process();
 
-	t.deepEqual(res.getValue(), f32(3, 9, 15, NaN));
+	t.deepEqual(res.getValue(), f32(6, 11, 19));
 });
 
 test('Arithmetic - Sequence order: invalid', async (t) => {

--- a/src/lib/processing/arithmetic.spec.ts
+++ b/src/lib/processing/arithmetic.spec.ts
@@ -125,7 +125,7 @@ test('Arithmetic - Sequence order: forward', async(t) => {
 	t.deepEqual(res.getValue(), f32(3, 9, 15));
 });
 
-test('Arithmetic - Sequence order: none, differing lengths', async (t) => {
+test('Arithmetic - Sequence order: none, differing lengths', async(t) => {
 	const step = mockStep(AdditionStep, [frameSignal1, frameSignal2], {
 		frameSequenceOrder: FrameSequenceOperandOrder.None
 	});
@@ -133,7 +133,7 @@ test('Arithmetic - Sequence order: none, differing lengths', async (t) => {
 	await t.throwsAsync(step.process());
 });
 
-test('Arithmetic - Sequence order: none, same length', async (t) => {
+test('Arithmetic - Sequence order: none, same length', async(t) => {
 	const step = mockStep(AdditionStep, [frameSignal2, frameSignal3], {
 		frameSequenceOrder: FrameSequenceOperandOrder.None
 	});


### PR DESCRIPTION
Throws an error when both operands are arrays or component-based (marker/vector/segment) but with different length or with different number of components, since there is no defined way to apply the operation.