### PR TITLE
Improved handling of double wrapped inputs

### DIFF
--- a/src/lib/processing/events/peak-finder.spec.ts
+++ b/src/lib/processing/events/peak-finder.spec.ts
@@ -23,18 +23,18 @@ test('PeakFinderStep - Wrong input signals', async(t) => {
 });
 
 test('PeakFinderStep - Options - height', async(t) => {
-	t.is(mockStep(PeakFinderStep, [], { height: 10 }).height, 10);
+	t.like(mockStep(PeakFinderStep, [], { height: 10 }).height, { min: 10, max: undefined });
 	t.like(mockStep(PeakFinderStep, [], { height: [10, 20] }).height, { min: 10, max: 20 });
 	t.like(mockStep(PeakFinderStep, [], { height: [10] }).height, { min: 10, max: undefined });
 });
 
 test('PeakFinderStep - Options - width', async(t) => {
-	t.is(mockStep(PeakFinderStep, [], { width: 10 }).width, 10);
+	t.like(mockStep(PeakFinderStep, [], { width: 10 }).width, { min: 10, max: undefined });
 	t.like(mockStep(PeakFinderStep, [], { width: [10, 20] }).width, { min: 10, max: 20 });
 });
 
 test('PeakFinderStep - Options - prominence', async(t) => {
-	t.is(mockStep(PeakFinderStep, [], { prominence: 10 }).prominence, 10);
+	t.like(mockStep(PeakFinderStep, [], { prominence: 10 }).prominence, { min: 10, max: undefined });
 	t.like(mockStep(PeakFinderStep, [], { prominence: [10, 20] }).prominence, { min: 10, max: 20 });
 });
 

--- a/src/lib/processing/events/peak-finder.ts
+++ b/src/lib/processing/events/peak-finder.ts
@@ -240,10 +240,10 @@ export class PeakFinderStep extends BaseStep {
 
 	init() {
 		super.init();
-
-		this.height = this.parseRangeArgument(this.getPropertyValue<number[] | number[][]>('height', [PropertyType.Number, PropertyType.Array])?.shift());
-		this.width = this.parseRangeArgument(this.getPropertyValue<number[] | number[][]>('width', [PropertyType.Number, PropertyType.Array])?.shift());
-		this.prominence = this.parseRangeArgument(this.getPropertyValue<number[] | number[][]>('prominence', [PropertyType.Number, PropertyType.Array])?.shift());
+	
+		this.height = this.parseRangeArgument(this.getPropertyValue<number[] | number[][]>('height', [PropertyType.Number, PropertyType.Array]));
+		this.width = this.parseRangeArgument(this.getPropertyValue<number[] | number[][]>('width', [PropertyType.Number, PropertyType.Array]));
+		this.prominence = this.parseRangeArgument(this.getPropertyValue<number[] | number[][]>('prominence', [PropertyType.Number, PropertyType.Array]));
 
 		this.distance = this.getPropertyValue('distance', PropertyType.Number);
 		this.relHeight = this.getPropertyValue('relHeight', PropertyType.Number);
@@ -283,7 +283,12 @@ export class PeakFinderStep extends BaseStep {
 		return result;
 	}
 
-	protected parseRangeArgument(span: number | number[]): number | IValueRange {
+	protected parseRangeArgument(span: number | number[] | number[][]): IValueRange {
+		// Handle double-wrapped arrays
+		if (TypeCheck.isArrayLike(span) && TypeCheck.isArrayLike(span[0])) {
+			span = span.shift();
+		}
+
 		if (span && TypeCheck.isArrayLike(span)) {
 			return {
 				min: span[0],
@@ -291,6 +296,9 @@ export class PeakFinderStep extends BaseStep {
 			};
 		}
 
-		return span as number;
+		return {
+			min: span as number,
+			max: undefined,
+		};
 	}
 }

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -18,7 +18,7 @@ const sArray = new Signal(f32(3, 4, 5));
 const sArray2 = new Signal(f32(3));
 const sArray3 = new Signal(i32(1));
 
-test('IfStep (mock) - Missing then ', async(t) => {
+test('IfStep (mock) - Missing "then"', async(t) => {
 	const step = mockStep(IfStep, [s1, s2], {
 		else: [s10],
 	}, '1 > 2');
@@ -26,9 +26,36 @@ test('IfStep (mock) - Missing then ', async(t) => {
 	await t.throwsAsync(step.process());
 });
 
-test('IfStep (mock) - Missing else ', async(t) => {
+test('IfStep (mock) - Missing "else"', async(t) => {
 	const step = mockStep(IfStep, [s1, s2], {
 		then: [s10],
+	}, '1 > 2');
+
+	await t.throwsAsync(step.process());
+});
+
+test('IfStep (mock) - More than one input to "then" option', async(t) => {
+	const step = mockStep(IfStep, [s1, s2], {
+		then: [s1, s2],
+		else: [s10],
+	}, '1 > 2');
+
+	await t.throwsAsync(step.process());
+});
+
+test('IfStep (mock) - More than one input to "else" option', async(t) => {
+	const step = mockStep(IfStep, [s1, s2], {
+		then: [s0, s1],
+		else: [s1, s2],
+	}, '1 > 2');
+
+	await t.throwsAsync(step.process());
+});
+
+test('IfStep (mock) - More than one input to both "then" and "else" options', async(t) => {
+	const step = mockStep(IfStep, [s1, s2], {
+		then: [s1, s2],
+		else: [s1, s2],
 	}, '1 > 2');
 
 	await t.throwsAsync(step.process());

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -79,11 +79,19 @@ export class IfStep extends BaseStep {
 		const operands = parseExpressionOperands(exp);
 		const expressionValues = {};
 
-		const thenInput = this.getPropertySignalValue('then')[0];
-		const elseInput = this.getPropertySignalValue('else')[0];
+		const thenInput = this.getPropertySignalValue('then');
+		const elseInput = this.getPropertySignalValue('else');
 
 		if (!thenInput || !elseInput) {
 			throw new ProcessingError('Missing \'then\' and/or \'else\' options.');
+		}
+
+		if (thenInput.length > 1) {
+			throw new ProcessingError(`Unexpected input length for 'then' option. Expected 1 input, got ${ thenInput.length }.`);
+		}
+
+		if (elseInput.length > 1) {
+			throw new ProcessingError(`Unexpected input length for 'else' option. Expected 1 input, got ${ elseInput.length }.`);
 		}
 
 		for (let i = 0; i < operands.length; i++) {
@@ -114,7 +122,7 @@ export class IfStep extends BaseStep {
 
 			this.processingLogs.push('Evaluated to: ' + result);
 
-			return result ? thenInput : elseInput;
+			return result ? thenInput[0] : elseInput[0];
 		}
 		catch (err) {
 			throw new ProcessingError('Evaluating expression failed: ' + err.message);


### PR DESCRIPTION
This PR adds an error when providing more than one input to `then` and `else` of an `if` step and allows for double wrapping range inputs in `peakFinder` steps.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [ ] ~Documentation added~

### Example
Show example in yaml file...

``` yaml
- parameter: unitVector
  where:
    name: Cycling*
  steps:
    - segment: RightFoot => rfoot
    - unitVector: rfoot
```
[AB#5960](https://qualisys.visualstudio.com/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/5960)