### PR TITLE
Feature/unwrap angles

### DIFF
--- a/docs/nodes/steps/angle.md
+++ b/docs/nodes/steps/angle.md
@@ -55,6 +55,45 @@ The following options are available on all Angle steps.
 > - ZXZ
 > - ZYZ
 >
+> #### `unwrap`
+>
+> **Type:** `Boolean | Event | Number`  
+> **Required:** `False`  
+> **Default value:** `XYZ`  
+>
+> When set to `true`, an event, or a numeric value, the unwrap option 
+> shifts the angle phases in order to achieve a continuous curve, i.e., 
+> it tries to detect when an angle crosses over its available range 
+> (-PI to PI for radians, -180 to 180 degrees).
+>
+> This allows for tracking angles on movements that goes outside of the
+> typical angle range.
+>
+> To do this, it looks for jumps between consecutive angles. If the jump
+> is greater than a threshold of half the range (PI for radians, 180 for 
+> degrees), the angle is shifted by adding multiples of of the range until 
+> the jump no longer crosses the threshold.
+>
+> The unwrap algorithm is run over all available components.
+>
+> If set to `true` or `0`, the algorithm aligns the unwrap to the start 
+> of the sequence. I.e., it assumes the first frame is correct in being 
+> within the original range and the following angles are moved to follow 
+> suit.
+>
+> If set to an `Event` or a `Number`, the algorithm will assume that
+> the corresponding frame is correct in being within the original range. 
+> All other angles will be shifted to follow suit. This enables tracking 
+> a rotational movement where the angle for a specific event is intended
+> to be within the standard range (-PI to PI for radians, -180 to 180 
+> degrees).
+>
+> IF a supplied event has more than one instance, the first instance is used.
+>
+> **_Note:_** _The unwrap algorithm is sensitive to noise, which may 
+> introduce unexpected artifacts. Please consider filtering the signal(s) 
+> before calculating its angle using unwrap._
+>
 >
 
 
@@ -83,6 +122,7 @@ The following options are available on all Angle steps.
 >
 > * [project](#project)
 > * [rotationOrder](#rotationorder)
+> * [unwrap](#unwrap)
 >
 >
 ></details>
@@ -175,6 +215,7 @@ specified as arrays or with named vector signals (ie markers).
 >
 > * [project](#project)
 > * [rotationOrder](#rotationorder)
+> * [unwrap](#unwrap)
 >
 >
 ></details>
@@ -227,6 +268,7 @@ in your instance**.
 >
 > * [project](#project)
 > * [rotationOrder](#rotationorder)
+> * [unwrap](#unwrap)
 >
 >
 ></details>
@@ -287,6 +329,7 @@ three or four inputs.
 >
 > * [project](#project)
 > * [rotationOrder](#rotationorder)
+> * [unwrap](#unwrap)
 >
 >
 ></details>

--- a/src/lib/processing/base-step.ts
+++ b/src/lib/processing/base-step.ts
@@ -103,7 +103,9 @@ export class BaseStep {
 			const optionSignals = this.getPropertySignalValue(key, expectedType, false);
 			const unpackedSignals = optionSignals.map(s => s.getValue());
 			const result = expectedTypes.includes(PropertyType.Array) || unpackedSignals.length > 1 ? unpackedSignals : unpackedSignals[0];
-
+			
+			if (result === undefined) throw 'Try property value';
+			
 			return result as unknown as T;
 		}
 		catch (e) {

--- a/src/lib/utils/math/angle.ts
+++ b/src/lib/utils/math/angle.ts
@@ -157,4 +157,57 @@ export class AngleUtil {
 
 		return result;
 	}
+
+	static unwrapAngles(angles: TypedArray, alignIndex = 0, range = 2 * Math.PI, threshold = Math.PI) {
+		if (!angles || !angles.length) {
+			throw new Error('No angles provided to unwrap.');
+		}
+
+		// Clamp alignment index to be within the angle index bounds.
+		alignIndex = Math.min(angles.length - 1, Math.max(0, alignIndex));
+		alignIndex = Math.floor(alignIndex);
+
+		// Make clone of input array.
+		const wrappedAngles = angles.slice(0);
+
+		if (angles.length === 1) return wrappedAngles;
+
+		let pm1 = angles[0];
+		let offset = 0;
+
+		for (let i = 1; i < wrappedAngles.length; i++) {
+			let currentValue = angles[i] + offset;
+			let delta = currentValue - pm1;
+			pm1 = currentValue;
+
+			if (delta > threshold) {
+				while (delta > threshold) {
+					offset = offset - range;
+					delta = delta - range;
+				}
+			}
+
+			if (delta < -threshold) {
+				while (delta < -threshold) {
+					offset = offset + range;
+					delta = delta + range;
+				}
+			}
+
+			currentValue = angles[i] + offset;
+			pm1 = currentValue;
+			wrappedAngles[i] = currentValue;
+		}
+
+		if (alignIndex === 0) return wrappedAngles;
+
+		/**
+		 * Find the difference between the original angle and
+		 * the unwrapped angle at the alignment index. 
+		 * Apply the difference to the entire signal.
+		 */
+		const diff = wrappedAngles[alignIndex] - angles[alignIndex];
+		return wrappedAngles.map(v => v - diff);
+
+	}
 }


### PR DESCRIPTION
Added an `unwrap` option to the angle steps. From the docs for the new option:

> #### `unwrap`
>
> **Type:** `Boolean | Event | Number`  
> **Required:** `False`  
> **Default value:** `XYZ`  
>
> When set to `true`, an event, or a numeric value, the unwrap option 
> shifts the angle phases in order to achieve a continuous curve, i.e., 
> it tries to detect when an angle crosses over its available range 
> (-PI to PI for radians, -180 to 180 degrees).
>
> This allows for tracking angles on movements that goes outside of the
> typical angle range.
>
> To do this, it looks for jumps between consecutive angles. If the jump
> is greater than a threshold of half the range (PI for radians, 180 for 
> degrees), the angle is shifted by adding multiples of of the range until 
> the jump no longer crosses the threshold.
>
> The unwrap algorithm is run over all available components.
>
> If set to `true` or `0`, the algorithm aligns the unwrap to the start 
> of the sequence. I.e., it assumes the first frame is correct in being 
> within the original range and the following angles are moved to follow 
> suit.
>
> If set to an `Event` or a `Number`, the algorithm will assume that
> the corresponding frame is correct in being within the original range. 
> All other angles will be shifted to follow suit. This enables tracking 
> a rotational movement where the angle for a specific event is intended
> to be within the standard range (-PI to PI for radians, -180 to 180 
> degrees).
>
> IF a supplied event has more than one instance, the first instance is used.
>
> **_Note:_** _The unwrap algorithm is sensitive to noise, which may 
> introduce unexpected artifacts. Please consider filtering the signal(s) 
> before calculating its angle using unwrap._

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Example
The following unwraps a bat angle, keeping the angle at the Impact event within the normal range.

``` yaml
- parameter: Bat_Angle
  steps:
    - angle: [VirtualLabSegment, Bat]
      space: VirtualLab
      unwrap: Impact
```

[AB#9426](https://qualisys.visualstudio.com/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/9426)