### PR TITLE
Refine event step

### DIFF
--- a/docs/nodes/steps/event-utility.md
+++ b/docs/nodes/steps/event-utility.md
@@ -192,6 +192,14 @@ The time is calculated using the frame rate from the signal.
 >
 > Event(s) that will invalidate an event sequence if found within it.
 >
+> #### `cyclic`
+>
+> **Type:** `Boolean`  
+> **Required:** `False`  
+> **Default value:** `True`  
+>
+> Whether or not to treat sequences as cyclic (`true` as default).
+>
 
 **Shared options**
 >
@@ -227,6 +235,15 @@ be picked from this sequence.
 
 The `exclude` option cannot contain any signals defined in the 
 `sequence` option.
+
+The optional option `cyclic` defines whether or not the sequence should 
+be treated as cyclic, i.e., if the sequence starts and ends with the same 
+events, those events are included in the next "match-finding" iteration 
+of the sequence. This is useful for refining event cycles where the end 
+event is the start event of the next cycle.
+
+The `cyclic` option is `true` by default and has to be explicitly set 
+to `false` to disable.
 
 ---
 

--- a/docs/nodes/steps/event-utility.md
+++ b/docs/nodes/steps/event-utility.md
@@ -3,6 +3,7 @@
 - [eventDuration](#eventduration)
 - [eventMask](#eventmask)
 - [eventTime](#eventtime)
+- [refineEvent](#refineevent)
 
 These are steps that uses events as inputs to affect the output 
 in various ways.
@@ -163,6 +164,69 @@ This step takes an event input and converts each frame value
 to a time value (in seconds).
 
 The time is calculated using the frame rate from the signal.
+
+---
+
+### `refineEvent`
+
+**Inputs**
+>
+> 1. `Event`
+>
+
+**Output:** `Event`
+
+**Options**
+>
+> #### `sequence`
+>
+> **Type:** `Event[]`  
+> **Required:** `True`  
+>
+> A sequence of events. This must include at least one instance of the main input event.
+>
+> #### `exclude`
+>
+> **Type:** `Event[]`  
+> **Required:** `False`  
+>
+> Event(s) that will invalidate an event sequence if found within it.
+>
+
+**Shared options**
+>
+> <details><summary>Global options</summary>
+> 
+> The following options are available globally on all steps.
+>
+> * [export](./index.md#export)
+> * [output](./index.md#output)
+> * [set](./index.md#set)
+> * [space](./index.md#space)
+>
+>
+></details>
+>
+
+
+This step allows you to easily pick out frames from an event only when 
+they appear in a specific sequence of other events.
+
+The main input of this step is the event you want to select frames from.
+
+The required option `sequence` defines a sequence of events to happen 
+in order. This option requires at least one instance of the main input 
+event (otherwise, no event would be able to be picked from the sequence).
+
+Multiple instances of the main input event can be supplied to the sequence
+to enable more complex patterns of events.
+
+The optional option `exclude` defines events that cannot occur in a 
+sequence. If it does, the sequence is invalidated, meaning no events will 
+be picked from this sequence.
+
+The `exclude` option cannot contain any signals defined in the 
+`sequence` option.
 
 ---
 

--- a/src/lib/processing/events/refine-event.spec.ts
+++ b/src/lib/processing/events/refine-event.spec.ts
@@ -1,0 +1,70 @@
+import test from 'ava';
+
+import { f32, mockStep } from '../../../test-utils/mock-step';
+import { VectorSequence } from '../../models/sequence/vector-sequence';
+import { Signal } from '../../models/signal';
+
+import { RefineEventStep } from './refine-event';
+
+const framesA = f32(1, 5, 10, 15, 20);
+const framesB = f32(2, 6, 11, 16);
+const framesC = f32(3, 7, 12, 17, 22);
+const framesX1 = f32(1.5, 16.5);
+
+const vs = new VectorSequence(framesA, framesA, framesA);
+const sVS = new Signal(vs);
+
+const sA = new Signal(framesA);
+const sB = new Signal(framesB);
+const sC = new Signal(framesC);
+const sX = new Signal(framesX1);
+
+/** 
+ * The following tests verify the *input handling*. The pattern handling is
+ * tested in lib/utils/events.spec.ts
+ */
+
+test('RefineEventStep - Wrong input signals', async t => {
+	await t.throws(() => mockStep(RefineEventStep, [sA])); // No sequence
+	await t.throwsAsync(mockStep(RefineEventStep, undefined, { sequence: [sA, sB, sC] }).process()); // No inputs
+	await t.throwsAsync(mockStep(RefineEventStep, [sA], { sequence: [] }).process()); // No sequence
+	await t.throwsAsync(mockStep(RefineEventStep, [sVS], { sequence: [sA, sB, sC] }).process()); // Wrong input type
+	await t.throwsAsync(mockStep(RefineEventStep, [sA], { sequence: [sA, sVS, sC] }).process()); // Wrong input type in sequence
+	await t.throwsAsync(mockStep(RefineEventStep, [sA, sB], { sequence: [sA, sB, sC] }).process()); // Multiple inputs
+	await t.throwsAsync(mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC], exclude: [sVS] }).process()); // Wrong input type in exclude
+	await t.throwsAsync(mockStep(RefineEventStep, [sA], { sequence: [sB, sC], exclude: [sX] }).process()); // Input not found in sequence
+	await t.throwsAsync(mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC], exclude: [sB] }).process()); // Sequence signal found in exclude
+});
+
+test('RefineEventStep - Options - sequence & exclude', async t => {
+	const step = mockStep(RefineEventStep, [sA], { sequence: [sA, sVS, sC], exclude: [sX] });
+
+	t.deepEqual(step.sequence, [sA, sVS, sC]);
+	t.deepEqual(step.exclude, [sX]);
+});
+
+test('RefineEventStep - Result - sequence only', async t => {
+	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC] }).process();
+
+	t.deepEqual(res.getValue(), f32(1, 5, 10, 15));
+});
+
+test('RefineEventStep - Result - sequence & exclude', async t => {
+	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC], exclude: [sX] }).process();
+
+	t.deepEqual(res.getValue(), f32(5, 10));
+});
+
+test('RefineEventStep - makeArray', async t => {
+	const farr = f32(1, 2, 3);
+	const arr = [1, 2, 3];
+	t.is(RefineEventStep.makeArray(farr), farr);
+	t.is(RefineEventStep.makeArray(arr), arr);
+	t.deepEqual(RefineEventStep.makeArray(1), f32(1));
+	t.deepEqual(RefineEventStep.makeArray(NaN), f32(NaN));
+
+	t.throws(() => RefineEventStep.makeArray('test'));
+	t.throws(() => RefineEventStep.makeArray({ hello: 'world' }));
+	t.throws(() => RefineEventStep.makeArray(undefined));
+	t.throws(() => RefineEventStep.makeArray(null));
+});

--- a/src/lib/processing/events/refine-event.spec.ts
+++ b/src/lib/processing/events/refine-event.spec.ts
@@ -36,11 +36,17 @@ test('RefineEventStep - Wrong input signals', async t => {
 	await t.throwsAsync(mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC], exclude: [sB] }).process()); // Sequence signal found in exclude
 });
 
-test('RefineEventStep - Options - sequence & exclude', async t => {
-	const step = mockStep(RefineEventStep, [sA], { sequence: [sA, sVS, sC], exclude: [sX] });
+test('RefineEventStep - Options - sequence, exclude & cyclic', async t => {
+	const step1 = mockStep(RefineEventStep, [sA], { sequence: [sA, sVS, sC], exclude: [sX] });
 
-	t.deepEqual(step.sequence, [sA, sVS, sC]);
-	t.deepEqual(step.exclude, [sX]);
+	t.deepEqual(step1.sequence, [sA, sVS, sC]);
+	t.deepEqual(step1.exclude, [sX]);
+	// Cyclic is true by default
+	t.is(step1.cyclic, true);
+
+	const step2 = mockStep(RefineEventStep, [sA], { sequence: [sA, sVS, sC], cyclic: false });
+
+	t.is(step2.cyclic, false);
 });
 
 test('RefineEventStep - Result - sequence only', async t => {
@@ -51,6 +57,18 @@ test('RefineEventStep - Result - sequence only', async t => {
 
 test('RefineEventStep - Result - sequence & exclude', async t => {
 	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC], exclude: [sX] }).process();
+
+	t.deepEqual(res.getValue(), f32(5, 10));
+});
+
+test('RefineEventStep - Result - cyclic true', async t => {
+	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC, sA], exclude: [sX], cyclic: true }).process();
+
+	t.deepEqual(res.getValue(), f32(5, 10, 15));
+});
+
+test('RefineEventStep - Result - cyclic false', async t => {
+	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC, sA], exclude: [sX], cyclic: false }).process();
 
 	t.deepEqual(res.getValue(), f32(5, 10));
 });

--- a/src/lib/processing/events/refine-event.ts
+++ b/src/lib/processing/events/refine-event.ts
@@ -1,0 +1,160 @@
+import { PropertyType } from '../../models/property';
+import { ResultType, Signal } from '../../models/signal';
+import { StepClass } from '../../step-registry';
+import { EventUtil } from '../../utils/events';
+import { ProcessingError } from '../../utils/processing-error';
+import { markdownFmt } from '../../utils/template-literal-tags';
+import { TypeCheck } from '../../utils/type-check';
+import { BaseStep } from '../base-step';
+
+@StepClass({
+	name: 'refineEvent',
+	category: 'Event utility',
+	description: markdownFmt`
+		This step allows you to easily pick out frames from an event only when 
+		they appear in a specific sequence of other events.
+
+		The main input of this step is the event you want to select frames from.
+
+		The required option ''sequence'' defines a sequence of events to happen 
+		in order. This option requires at least one instance of the main input 
+		event (otherwise, no event would be able to be picked from the sequence).
+
+		Multiple instances of the main input event can be supplied to the sequence
+		to enable more complex patterns of events.
+
+		The optional option ''exclude'' defines events that cannot occur in a 
+		sequence. If it does, the sequence is invalidated, meaning no events will 
+		be picked from this sequence.
+
+		The ''exclude'' option cannot contain any signals defined in the 
+		''sequence'' option.
+	`,
+	examples: markdownFmt`
+		This example picks the frames of event ''A'' only when it's followed 
+		by an event frame from the events ''B'' and ''C'', respectively.
+
+		'''yaml
+		- event: RefinedEvent
+		  steps:
+		    - refineEvent: A
+		      sequence: [A, B, C]
+		'''
+
+		The next example does the same as above but also excludes sequences where 
+		an error named ''ERR'' occurs within.
+
+		'''yaml
+		- event: RefinedEvent
+		  steps:
+		    - refineEvent: A
+		      sequence: [A, B, C]
+		      exclude: [ERR]
+		'''
+
+		This example has a more intricate event pattern and picks the frames of 
+		event ''A'' only when it's followed by an event frame from the events 
+		''B'' and ''C'', then another instance of ''A'' followed by an event 
+		frame from the events ''D'' and ''E'', respectively.
+
+		This will return two frames from ''A'' for each complete sequence found.
+
+		'''yaml
+		- event: RefinedEvent
+		  steps:
+		    - refineEvent: A
+		      sequence: [A, B, C, A, D, E]
+		'''
+`,
+	inputs: [
+		{ type: ['Event'] },
+	],
+	options: [{
+		name: 'sequence',
+		type: 'Event[]',
+		required: true,
+		description: markdownFmt`
+			A sequence of events. This must include at least one instance of the main input event.
+		`,
+	}, {
+		name: 'exclude',
+		type: 'Event[]',
+		required: false,
+		description: markdownFmt`
+			Event(s) that will invalidate an event sequence if found within it.
+		`,
+	}],
+	output: ['Event'],
+})
+export class RefineEventStep extends BaseStep {
+	sequence: Signal[];
+	exclude: Signal[];
+
+	init() {
+		super.init();
+
+		this.sequence = this.getPropertySignalValue('sequence', PropertyType.Any, true);
+		this.exclude = this.getPropertySignalValue('exclude', PropertyType.Any, false);
+	}
+
+	async process(): Promise<Signal> {
+		if (!this.inputs || !this.inputs.length) {
+			throw new ProcessingError('No valid inputs.');
+		}
+
+		if (this.inputs.length > 1) {
+			throw new ProcessingError('Only one input is allowed.');
+		}
+
+		const referenceSignal = this.inputs[0];
+
+		if (!referenceSignal.isEventLike) {
+			throw new ProcessingError('The refine event step expects an event as input.');
+		}
+
+		if (this.sequence.find(s => !s.isEventLike)) {
+			throw new ProcessingError('The refine event step expects only events in the sequence option.');
+		}
+
+		if (this.exclude && this.exclude.find(s => !s.isEventLike)) {
+			throw new ProcessingError('The refine event step expects only events in the exclude option.');
+		}
+
+		// Verify that the reference signal is found in the sequence option.
+		if (!this.sequence.find(s => s.getValue() === referenceSignal.getValue())) throw new ProcessingError('The reference event signal was not found in the "sequence" option.');
+
+		// Verify that the any of the sequence signals are NOT found in the exclude option.
+		if (this.exclude && this.exclude.find(s => this.sequence.find(v => v.getValue() === s.getValue()))) throw new ProcessingError('The "exclude" option cannot contain any signals from the "sequence" option.');
+
+		const seqValues = this.sequence.map(s => RefineEventStep.makeArray(s.getValue()));
+		const excludeValues = (this.exclude) ? this.exclude.map(s => RefineEventStep.makeArray(s.getValue())) : undefined;
+
+		const refinedEvent = EventUtil.pickFromSequence(
+			referenceSignal.getValue() as NumericArray, 
+			seqValues as NumericArray[],
+			excludeValues as NumericArray[],
+		);
+
+		const result: Signal = referenceSignal.clone(refinedEvent);
+
+		result.isEvent = true;
+		result.resultType = ResultType.Scalar;
+
+		return result;
+	}
+
+	/**
+	 * Takes any value and returns an array if the input
+	 * was an array or if the input was a number.
+	 * 
+	 * If the input is of any other type, it throws an error.
+	 * @param value 
+	 * @returns 
+	 */
+	static makeArray(value: unknown): NumericArray {
+		if (TypeCheck.isArrayLike(value)) return value;
+		if (typeof value === 'number') return new Float32Array([value]);
+
+		throw new ProcessingError('The value provided was not numeric.');
+	}
+}

--- a/src/lib/processing/events/refine-event.ts
+++ b/src/lib/processing/events/refine-event.ts
@@ -29,6 +29,15 @@ import { BaseStep } from '../base-step';
 
 		The ''exclude'' option cannot contain any signals defined in the 
 		''sequence'' option.
+
+		The optional option ''cyclic'' defines whether or not the sequence should 
+		be treated as cyclic, i.e., if the sequence starts and ends with the same 
+		events, those events are included in the next "match-finding" iteration 
+		of the sequence. This is useful for refining event cycles where the end 
+		event is the start event of the next cycle.
+
+		The ''cyclic'' option is ''true'' by default and has to be explicitly set 
+		to ''false'' to disable.
 	`,
 	examples: markdownFmt`
 		This example picks the frames of event ''A'' only when it's followed 
@@ -83,18 +92,28 @@ import { BaseStep } from '../base-step';
 		description: markdownFmt`
 			Event(s) that will invalidate an event sequence if found within it.
 		`,
+	}, {
+		name: 'cyclic',
+		type: 'Boolean',
+		required: false,
+		default: 'True',
+		description: markdownFmt`
+			Whether or not to treat sequences as cyclic (''true'' as default).
+		`,
 	}],
 	output: ['Event'],
 })
 export class RefineEventStep extends BaseStep {
 	sequence: Signal[];
 	exclude: Signal[];
+	cyclic: boolean;
 
 	init() {
 		super.init();
 
 		this.sequence = this.getPropertySignalValue('sequence', PropertyType.Any, true);
 		this.exclude = this.getPropertySignalValue('exclude', PropertyType.Any, false);
+		this.cyclic = this.getPropertyValue<boolean>('cyclic', PropertyType.Boolean, false, true);
 	}
 
 	async process(): Promise<Signal> {
@@ -133,6 +152,7 @@ export class RefineEventStep extends BaseStep {
 			referenceSignal.getValue() as NumericArray, 
 			seqValues as NumericArray[],
 			excludeValues as NumericArray[],
+			this.cyclic,
 		);
 
 		const result: Signal = referenceSignal.clone(refinedEvent);

--- a/src/lib/processing/index.ts
+++ b/src/lib/processing/index.ts
@@ -111,6 +111,7 @@ export * from './events/event-duration';
 export * from './events/event-mask';
 export * from './events/event-time';
 export * from './events/peak-finder';
+export * from './events/refine-event';
 export * from './events/threshold';
 
 // Data structures

--- a/src/lib/utils/events.spec.ts
+++ b/src/lib/utils/events.spec.ts
@@ -61,3 +61,31 @@ test('EventUtil - pickFromSequence', (t) => {
 	const evt9 = EventUtil.pickFromSequence(framesB1, [framesA, framesB1, framesC, framesA, framesB1], [framesX1]);
 	t.deepEqual(evt9, f32(6, 11));
 });
+
+test('EventUtil - pickFromSequence (cyclic)', (t) => {
+	const framesA  = f32(1, 5, 10, 15, 20);
+	const framesB1 = f32(2, 6, 11, 16);
+	const framesB2 = f32(2, 6,     16);
+	const framesC  = f32(3, 7, 12, 17, 22);
+
+	const framesX1 = f32(1.5, 16.5);
+	const framesX2 = f32(6.5);
+
+	const evt1 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], undefined, true);
+	t.deepEqual(evt1, f32(1, 5, 10, 15, 20));
+
+	const evt2 = EventUtil.pickFromSequence(framesA, [framesA, framesB2, framesC, framesA], undefined, true);
+	t.deepEqual(evt2, f32(1, 5, 10, 15, 20));
+
+	const evt3 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], [framesX1], true);
+	t.deepEqual(evt3, f32(5, 10, 15));
+
+	const evt4 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], [framesX2], true);
+	t.deepEqual(evt4, f32(1, 5, 10, 15, 20));
+
+	const evt5 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], [framesX1, framesX2]);
+	t.deepEqual(evt5, f32(10, 15));
+
+	const evt9 = EventUtil.pickFromSequence(framesB1, [framesA, framesB1, framesC, framesA, framesB1], [framesX1], true);
+	t.deepEqual(evt9, f32(6, 11, 16));
+});

--- a/src/lib/utils/events.spec.ts
+++ b/src/lib/utils/events.spec.ts
@@ -1,5 +1,7 @@
 import test from 'ava';
 
+import { f32 } from '../../test-utils/mock-step';
+
 import { EventUtil } from './events';
 
 test('EventUtil - eventSequence', (t) => {
@@ -17,4 +19,45 @@ test('EventUtil - eventSequence', (t) => {
 	const spans2 = EventUtil.eventSequence(framesA, []);
 
 	t.deepEqual(spans2, []);
+});
+
+
+test('EventUtil - pickFromSequence', (t) => {
+	const framesA  = f32(1, 5, 10, 15, 20);
+	const framesB1 = f32(2, 6, 11, 16);
+	const framesB2 = f32(2, 6,     16);
+	const framesC  = f32(3, 7, 12, 17, 22);
+
+	const framesX1 = f32(1.5, 16.5);
+	const framesX2 = f32(6.5);
+
+	const evt1 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC]);
+	t.deepEqual(evt1, f32(1, 5, 10, 15));
+
+	const evt2 = EventUtil.pickFromSequence(framesA, [framesA, framesB2, framesC]);
+	t.deepEqual(evt2, f32(1, 5, 15));
+
+	const evt3 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC], [framesX1]);
+	t.deepEqual(evt3, f32(5, 10));
+
+	const evt4 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC], [framesX2]);
+	t.deepEqual(evt4, f32(1, 10, 15));
+
+	const evt5 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC], [framesX1, framesX2]);
+	t.deepEqual(evt5, f32(10));
+
+	// The "pick" is not in the sequence
+	const evt6 = EventUtil.pickFromSequence(framesA, [f32(1, 5, 10, 15), framesB1, framesC]);
+	t.deepEqual(evt6, f32());
+
+	// No sequence provided
+	const evt7 = EventUtil.pickFromSequence(framesA, []);
+	t.deepEqual(evt7, f32());
+
+	// The "pick" appears multiple times in the sequence
+	const evt8 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA]);
+	t.deepEqual(evt8, f32(1, 5, 10, 15));
+
+	const evt9 = EventUtil.pickFromSequence(framesB1, [framesA, framesB1, framesC, framesA, framesB1], [framesX1]);
+	t.deepEqual(evt9, f32(6, 11));
 });

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -1,5 +1,12 @@
 import { IFrameSpan } from '../models/signal';
 
+import { SeriesUtil } from './series';
+
+interface ISequenceItem {
+	value: number;
+	from: NumericArray;
+}
+
 export class EventUtil {
 	/**
 	 * Returns an array of [[IFrameSpan]] objects, where the start frames
@@ -45,5 +52,77 @@ export class EventUtil {
 		}
 
 		return pairs;
+	}
+
+	/**
+	 * Given an array of event values – "pick" – together with a 
+	 * sequence of arrays of event values – "sequence" – returns 
+	 * event values from the former array that was found to fit 
+	 * in the correct order as defined by the sequence.
+	 * 
+	 * An optional array of arrays of event values can be used to 
+	 * exclude sequences, i.e., if such an event appears within the
+	 * defined sequence, the values from that sequence is ignored.
+	 * 
+	 * In order for this algorithm to return any values, the "pick" 
+	 * array must be present in the "sequence" array.
+	 * 
+	 * The pick array is identified using its instance, therefore,
+	 * you always need to send the exact same instance if the pick 
+	 * array both as the "pick" argument, as well as in the 
+	 * "sequence" argument. 
+	 * 
+	 * @param pick Event frames to pick from.
+	 * @param sequence Array of event frames, forming a sequence of events to happen in order.
+	 * @param exclude Array of event frames that, if present in a sequence, disqualifies the sequence.
+	 * @returns 
+	 */
+	static pickFromSequence(pick: NumericArray, sequence: NumericArray[], exclude: NumericArray[] = []): NumericArray {
+		const usedInstances = [];
+
+		// Construct a sequence using all the events in the sequence and exclude arrays.
+		const fullSequence = [...sequence, ...exclude].reduce((all, curr) => {
+			// Ignore duplicates of arrays already in the full sequence.
+			if (usedInstances.includes(curr)) return all;
+			usedInstances.push(curr);
+
+			const items: ISequenceItem[] = [...curr].map(v => {
+				return {
+					value: v,
+					from: curr,
+				};
+			});
+
+			all.push(...items);
+
+			return all;
+		}, [] as ISequenceItem[]);
+
+		// Order the full sequence by value.
+		fullSequence.sort((a, b) => a.value - b.value);
+
+		const matches = [];
+
+		// Find pattern in sequence (finite-state machine)
+		for (let i = 0; i <= fullSequence.length - sequence.length; i++) {
+			const currPicks = [];
+
+			for (let p = 0; p < sequence.length; p++) {
+				const currItem = fullSequence[i + p];
+
+				if (currItem.from !== sequence[p]) break;
+
+				if (currItem.from === pick) {
+					currPicks.push(currItem.value);
+				}
+
+				if (p === sequence.length - 1) {
+					matches.push(...currPicks);
+					i += p;
+				}
+			}
+		}
+
+		return SeriesUtil.createNumericArrayOfSameType(pick, matches);
 	}
 }


### PR DESCRIPTION
This step allows you to easily pick out frames from an event only when they appear in a specific sequence of other events.

The main input of this step is the event you want to select frames from.

The required option `sequence` defines a sequence of events to happen in order. This option requires at least one instance of the main input event (otherwise, no event would be able to be picked from the sequence).

Multiple instances of the main input event can be supplied to the sequence to enable more complex patterns of events.

The optional option `exclude` defines events that cannot occur in a sequence. If it does, the sequence is invalidated, meaning no events will be picked from this sequence.

The `exclude` option cannot contain any signals defined in the `sequence` option.

The optional option `cyclic` defines whether or not the sequence should be treated as cyclic, i.e., if the sequence starts and ends with the same events, those events are included in the next "match-finding" iteration of the sequence. This is useful for refining event cycles where the end event is the start event of the next cycle.

The `cyclic` option is `true` by default and has to be explicitly set to `false` to disable.

**Inputs**
>
> 1. `Event`
>

**Output:** `Event`

**Options**
>
> #### `sequence`
>
> **Type:** `Event[]`  
> **Required:** `True`  
>
> A sequence of events. This must include at least one instance of the main input event.
>
> #### `exclude`
>
> **Type:** `Event[]`  
> **Required:** `False`  
>
> Event(s) that will invalidate an event sequence if found within it.
>
> #### `cyclic`
>
> **Type:** `Boolean`  
> **Required:** `False`  
> **Default value:** `True`  
>
> Whether or not to treat sequences as cyclic (`true` as default).
>

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Examples

This example picks the frames of event `A` only when it's followed by an event frame from the events `B` and `C`, respectively.

```yaml
- event: RefinedEvent
  steps:
    - refineEvent: A
      sequence: [A, B, C]
```

The next example does the same as above but also excludes sequences where an error named `ERR` occurs within.

```yaml
- event: RefinedEvent
  steps:
    - refineEvent: A
      sequence: [A, B, C]
      exclude: [ERR]
```

This example has a more intricate event pattern and picks the frames of event `A` only when it's followed by an event frame from the events `B` and `C`, then another instance of `A` followed by an event frame from the events `D` and `E`, respectively.

This will return two frames from `A` for each complete sequence found.

```yaml
- event: RefinedEvent
  steps:
    - refineEvent: A
      sequence: [A, B, C, A, D, E]
```
