### PR TITLE
Max/min aggregation (for indices) fails for leading NaNs

### DIFF
--- a/src/lib/utils/math/aggregation.spec.ts
+++ b/src/lib/utils/math/aggregation.spec.ts
@@ -16,6 +16,10 @@ test('Aggregation - Max indices', (t) => {
 	t.deepEqual(Aggregation.maxIndices([1, 2, 3, 4, 5, 1, 2, 5, 4]), [4, 7]);
 });
 
+test('Aggregation - Max indices (leading NaN values)', (t) => {
+	t.deepEqual(Aggregation.maxIndices([NaN, NaN, NaN, 1, 2, 3, 4, 5, NaN, 1, 2, 5, 4, NaN, NaN]), [7, 11]);
+});
+
 test('Aggregation - Max indices (input error)', (t) => {
 	t.deepEqual(Aggregation.maxIndices([]), undefined);
 	t.deepEqual(Aggregation.maxIndices(undefined), undefined);
@@ -52,6 +56,10 @@ test('Aggregation - Min indices', (t) => {
 test('Aggregation - Min indices (input error)', (t) => {
 	t.deepEqual(Aggregation.minIndices([]), undefined);
 	t.deepEqual(Aggregation.minIndices(undefined), undefined);
+});
+
+test('Aggregation - Min indices (leading NaN values)', (t) => {
+	t.deepEqual(Aggregation.minIndices([NaN, NaN, NaN, 1, 2, 3, 4, 5, NaN, 1, 2, 5, 4, NaN, NaN]), [3, 9]);
 });
 
 test('Aggregation - Range', (t) => {

--- a/src/lib/utils/math/aggregation.ts
+++ b/src/lib/utils/math/aggregation.ts
@@ -124,12 +124,16 @@ export class Aggregation {
 		if (!values || !values.length) return undefined;
 
 		const indices = [0];
-		let currLeader = values[0];
+
+		// Find first non-NaN number to use as a basis for comparison.
+		let currLeader = values.find(v => !isNaN(v) && v !== null);
 
 		for (let i = 1; i < values.length; i++) {
 			const currVal = values[i];
 
-			if ((direction >= 0 && values[i] > currLeader) || (direction < 0 && values[i] < currLeader)) {
+			if (isNaN(currVal) || currVal === null) continue;
+			
+			if ((direction >= 0 && currVal > currLeader) || (direction < 0 && currVal < currLeader)) {
 				currLeader = currVal;
 
 				indices.length = 0;

--- a/src/lib/utils/math/aggregation.ts
+++ b/src/lib/utils/math/aggregation.ts
@@ -128,6 +128,10 @@ export class Aggregation {
 		// Find first non-NaN number to use as a basis for comparison.
 		let currLeader = values.find(v => !isNaN(v) && v !== null);
 
+		if (currLeader !== values[0]) {
+			indices.length = 0;
+		}
+
 		for (let i = 1; i < values.length; i++) {
 			const currVal = values[i];
 


### PR DESCRIPTION
Fixes an issue where the min/max aggregation (for indices) returns 0 when the input data starts with NaN.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [ ] Documentation added

### Example
Show example in yaml file...

``` yaml
- event: maxEvent
  steps:
    - max: [NaN, 1, 2, 3, 4, 3, 2, 1]
      frames: true
```
