### PR TITLE
Kinematics: Split on gaps

### DIFF
--- a/docs/nodes/steps/kinematic.md
+++ b/docs/nodes/steps/kinematic.md
@@ -44,6 +44,10 @@ Derives the input signal to the second order.
 **_Note:_** _Due to the temporal nature of this operation, 
 the resulting first and last frames will be null._
 
+**_Note:_** _This operation will split the series on gaps and 
+derive each "slice" individually. The first and last frame on 
+each "slice" will be null._
+
 ---
 
 ### `derivative`
@@ -81,6 +85,10 @@ Only the first and second order is supported.
 **_Note:_** _Due to the temporal nature of this operation, 
 the resulting first and last frames will be null._
 
+**_Note:_** _This operation will split the series on gaps and 
+derive each "slice" individually. The first and last frame on 
+each "slice" will be null._
+
 ---
 
 ### `velocity`
@@ -113,6 +121,10 @@ Derives the input signal to the first order.
 
 **_Note:_** _Due to the temporal nature of this operation, 
 the resulting first and last frame will be null._
+
+**_Note:_** _This operation will split the series on gaps and 
+derive each "slice" individually. The first and last frame on 
+each "slice" will be null._
 
 ---
 

--- a/src/lib/processing/algorithms/derivative.spec.ts
+++ b/src/lib/processing/algorithms/derivative.spec.ts
@@ -31,6 +31,36 @@ test('DerivativeStep with Float32Array, order = 1', async(t) => {
 	t.deepEqual(Array.from(derivative), [NaN, 1, 1, 1, 1, 1.5, 2, 3, 4, 4, 6, NaN]);
 });
 
+test('DerivativeStep with initial and trailing NaNs, order = 1', async(t) => {
+	const inputSignal = new Signal(f32(NaN, NaN, NaN, 1, 2, 3, 4, 5, 6, 8, 10, 14, 18, 22, 30, NaN, NaN, NaN), 1);
+
+	const step = mockStep(DerivativeStep, [inputSignal]);
+	const result = await step.process();
+	const derivative = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(derivative), [NaN, NaN, NaN, NaN, 1, 1, 1, 1, 1.5, 2, 3, 4, 4, 6, NaN, NaN, NaN, NaN]);
+});
+
+test('DerivativeStep with gaps, order = 1', async(t) => {
+	const inputSignal = new Signal(f32(1, 2, NaN, NaN, NaN, 3, 4, 5, 6, 8, 10, 14, NaN, NaN, NaN, 18, 22, 30), 1);
+
+	const step = mockStep(DerivativeStep, [inputSignal]);
+	const result = await step.process();
+	const derivative = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(derivative), [NaN, NaN, NaN, NaN, NaN, NaN, 1, 1, 1.5, 2, 3, NaN, NaN, NaN, NaN, NaN, 6, NaN]);
+});
+
+test('DerivativeStep with initial and trailing NaNs and gaps, order = 1', async(t) => {
+	const inputSignal = new Signal(f32(NaN, NaN, NaN, 1, 2, NaN, NaN, NaN, 3, 4, 5, 6, 8, 10, 14, NaN, NaN, NaN, 18, 22, 30, NaN, NaN, NaN), 1);
+
+	const step = mockStep(DerivativeStep, [inputSignal]);
+	const result = await step.process();
+	const derivative = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(derivative), [NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 1, 1, 1.5, 2, 3, NaN, NaN, NaN, NaN, NaN, 6, NaN, NaN, NaN, NaN]);
+});
+
 test('DerivativeStep with Float32Array, order = 2', async(t) => {
 	const inputSignal = new Signal(f32(1, 2, 3, 4, 5, 6, 8, 10, 14, 18, 22, 30), 1);
 	const inputSignal2 = new Signal(2);

--- a/src/lib/processing/algorithms/derivative.ts
+++ b/src/lib/processing/algorithms/derivative.ts
@@ -2,6 +2,7 @@ import { SignalType } from '../../models/signal';
 import { StepCategory, StepClass } from '../../step-registry';
 import { Kinematics } from '../../utils/math/kinematics';
 import { ProcessingError } from '../../utils/processing-error';
+import { SeriesSplitUtil } from '../../utils/series-split';
 import { markdownFmt } from '../../utils/template-literal-tags';
 
 import { BaseAlgorithmStep } from './base-algorithm';
@@ -53,7 +54,13 @@ export class DerivativeStep extends BaseAlgorithmStep {
 			order = Number.isInteger(orderArg) ? orderArg : 1;
 		}
 
-		return Kinematics.finiteDifference(dataSet, 1 / this.frameRate, order);
+		const splitCollection = SeriesSplitUtil.splitOnNaN(dataSet);
+
+		for (const split of splitCollection.splits) {
+			split.values = Kinematics.finiteDifference(split.values, 1 / this.frameRate, order);
+		}
+
+		return SeriesSplitUtil.merge(splitCollection) as TypedArray;
 	}
 
 	init() {

--- a/src/lib/processing/algorithms/derivative.ts
+++ b/src/lib/processing/algorithms/derivative.ts
@@ -26,6 +26,10 @@ import { BaseAlgorithmStep } from './base-algorithm';
 		
 		**_Note:_** _Due to the temporal nature of this operation, 
 		the resulting first and last frames will be null._
+
+		**_Note:_** _This operation will split the series on gaps and 
+		derive each "slice" individually. The first and last frame on 
+		each "slice" will be null._
 	`,
 	inputs: [
 		{ type: ['Scalar', 'Series', 'Event', 'Number'] },
@@ -81,6 +85,10 @@ export class DerivativeStep extends BaseAlgorithmStep {
 
 		**_Note:_** _Due to the temporal nature of this operation, 
 		the resulting first and last frame will be null._
+
+		**_Note:_** _This operation will split the series on gaps and 
+		derive each "slice" individually. The first and last frame on 
+		each "slice" will be null._
 	`,
 	inputs: [
 		{ type: ['Scalar', 'Series', 'Event', 'Number'] },
@@ -105,6 +113,10 @@ export class VelocityStep extends DerivativeStep {
 
 		**_Note:_** _Due to the temporal nature of this operation, 
 		the resulting first and last frames will be null._
+
+		**_Note:_** _This operation will split the series on gaps and 
+		derive each "slice" individually. The first and last frame on 
+		each "slice" will be null._
 	`,
 	inputs: [
 		{ type: ['Scalar', 'Series', 'Event', 'Number'] },

--- a/src/lib/utils/series-split.spec.ts
+++ b/src/lib/utils/series-split.spec.ts
@@ -1,0 +1,128 @@
+import test from 'ava';
+
+import { f32, i32 } from '../../test-utils/mock-step';
+
+import { SeriesSplitUtil } from './series-split';
+
+test('SeriesSplitUtil.splitOnNaN', t => {
+	t.throws(() => SeriesSplitUtil.splitOnNaN(undefined), { message: 'Invalid series.' });
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN([]), { splits: [
+		{ values: [], startIndex: 0 }
+	], originalLength: 0 });
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN([1, 2, 3, 4, 5]), { 
+		splits: [
+			{ 
+				values: [1, 2, 3, 4, 5],
+				startIndex: 0,
+			}
+		], 
+		originalLength: 5 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(1, 2, 3, 4, 5)), { 
+		splits: [
+			{ 
+				values: f32(1, 2, 3, 4, 5),
+				startIndex: 0,
+			}
+		], 
+		originalLength: 5 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, 1, 2, 3, 4, 5)), { 
+		splits: [
+			{ 
+				values: f32(1, 2, 3, 4, 5),
+				startIndex: 3,
+			}
+		], 
+		originalLength: 8 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(1, 2, 3, 4, 5, NaN, NaN, NaN)), { 
+		splits: [
+			{ 
+				values: f32(1, 2, 3, 4, 5),
+				startIndex: 0,
+			}
+		], 
+		originalLength: 8 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, 1, 2, 3, 4, 5, NaN, NaN, NaN)), { 
+		splits: [
+			{ 
+				values: f32(1, 2, 3, 4, 5),
+				startIndex: 3,
+			}
+		], 
+		originalLength: 11 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(1, 2, 3, NaN, NaN, NaN, 4, 5)), { 
+		splits: [
+			{ 
+				values: f32(1, 2, 3),
+				startIndex: 0,
+			}, { 
+				values: f32(4, 5),
+				startIndex: 6,
+			}
+		], 
+		originalLength: 8 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, 1, 2, 3, NaN, NaN, NaN, 4, 5, NaN, NaN, NaN)), { 
+		splits: [
+			{ 
+				values: f32(1, 2, 3),
+				startIndex: 3,
+			}, { 
+				values: f32(4, 5),
+				startIndex: 9,
+			}
+		], 
+		originalLength: 14 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, 1, NaN, 2, 3, NaN, NaN, NaN, 4, 5, NaN, NaN, NaN)), { 
+		splits: [
+			{ 
+				values: f32(1),
+				startIndex: 3,
+			}, { 
+				values: f32(2, 3),
+				startIndex: 5,
+			}, { 
+				values: f32(4, 5),
+				startIndex: 10,
+			}
+		], 
+		originalLength: 15 
+	});
+
+	t.deepEqual(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, NaN, NaN)), { 
+		splits: [
+			{
+				values: f32(),
+				startIndex: 5,
+			}
+		], 
+		originalLength: 5 
+	});
+});
+
+test('SeriesSplitUtil.mergeSplitSeries', t => {
+	t.throws(() => SeriesSplitUtil.merge(undefined));
+	t.throws(() => SeriesSplitUtil.merge({ splits: undefined, originalLength: 0 }));
+	t.throws(() => SeriesSplitUtil.merge({ splits: [], originalLength: 0 }));
+
+	t.deepEqual(SeriesSplitUtil.merge(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, NaN, NaN))), f32(NaN, NaN, NaN, NaN, NaN));
+	t.deepEqual(SeriesSplitUtil.merge(SeriesSplitUtil.splitOnNaN([1, 2, 3, 4, 5])), [1, 2, 3, 4, 5]);
+	t.deepEqual(SeriesSplitUtil.merge(SeriesSplitUtil.splitOnNaN(f32(1, 2, 3, 4, 5))), f32(1, 2, 3, 4, 5));
+	t.deepEqual(SeriesSplitUtil.merge(SeriesSplitUtil.splitOnNaN(i32(1, 2, 3, 4, 5))), i32(1, 2, 3, 4, 5));
+	t.deepEqual(SeriesSplitUtil.merge(SeriesSplitUtil.splitOnNaN(f32(NaN, NaN, NaN, 1, 2, 3, NaN, 4, 5, NaN, NaN, NaN))), f32(NaN, NaN, NaN, 1, 2, 3, NaN, 4, 5, NaN, NaN, NaN));
+
+});

--- a/src/lib/utils/series-split.ts
+++ b/src/lib/utils/series-split.ts
@@ -1,0 +1,90 @@
+import { SeriesUtil } from './series';
+
+export interface ISeriesSplitCollection {
+	splits: ISeriesSplit[];
+	originalLength: number;
+}
+
+export interface ISeriesSplit {
+	values: NumericArray;
+	startIndex: number;
+}
+
+export class SeriesSplitUtil {
+	/**
+	 * Splits a series into multiple series, where each series is separated by NaN values.
+	 * 
+	 * @param series The series to split.
+	 * @returns A collection of splits.
+	 * 
+	 * @throws Error if the series is invalid.
+	 */
+	static splitOnNaN(series: NumericArray): ISeriesSplitCollection {
+		if (series === undefined) {
+			throw new Error('Invalid series.');
+		}
+
+		const collection: ISeriesSplitCollection = {
+			splits: [],
+			originalLength: series.length,
+		};
+
+		let currValues: number[] = [];
+		let currStartIndex = 0;
+
+		for (let i = 0; i < series.length; i++) {
+			const v = series[i];
+
+			if (isNaN(v)) {
+				if (currValues.length > 0) {
+					collection.splits.push({
+						values: SeriesUtil.createNumericArrayOfSameType(series, currValues),
+						startIndex: currStartIndex,
+					});
+				}
+
+				currValues = [];
+				currStartIndex = i + 1;
+			}
+			else {
+				currValues.push(v);
+			}
+		}
+
+		if (currValues.length > 0 || collection.splits.length === 0) {
+			collection.splits.push({
+				values: SeriesUtil.createNumericArrayOfSameType(series, currValues),
+				startIndex: currStartIndex,
+			});
+		}
+
+		return collection;
+	}
+
+	/**
+	 * Merges a series split collection back into a single series.
+	 * 
+	 * @param splits The series split collection.
+	 * @returns The merged series.
+	 * 
+	 * @throws Error if the series split collection is invalid.
+	 * @throws Error if the series split collection is empty.
+	 */
+	static merge(splits: ISeriesSplitCollection): NumericArray {
+		if (!splits || splits.splits?.length === 0) {
+			throw new Error('Invalid series split collection.');
+		}
+
+		const result = SeriesUtil.createNumericArrayOfSameType(splits.splits[0].values, new Array(splits.originalLength));
+
+		for (let i = 0; i < splits.splits.length; i++) {
+			const split = splits.splits[i];
+
+			for (let j = 0; j < split.values.length; j++) {
+				result[split.startIndex + j] = split.values[j];
+			}
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
For Kinematic steps (`derivative`, `velocity`, `acceleration`), there was a problem where gaps in the data produce artefacts in the results, like spikes. This includes gaps in the beginning or end of the series.

This PR adds the functionality to split the input data on the gaps, then run the kinematics function on each split series independently. The processed split series is then merged back together and the result is a signal with the same length as the input, with the gaps in the same place, but with processed data in the continuous sections between the gaps.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

Work item: [AB#21123](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/21123)