### PR TITLE
Add "keep" option to the eventMask step.

### DIFF
--- a/docs/nodes/steps/event-utility.md
+++ b/docs/nodes/steps/event-utility.md
@@ -64,6 +64,21 @@ the "from", or "to" input event.
 
 **Options**
 >
+> #### `keep`
+>
+> **Type:** `Number | Number array`  
+> **Required:** `False`  
+> **Default value:** `null`  
+>
+> An index or an array of indices of events in each cycle to 
+> keep. This allows you to keep only a subset of event instances 
+> in each cycle.
+>
+> Negative numbers can be used to count from the end of the cycle, 
+> e.g. -1 is the last event in the cycle.
+>
+> **_Note:_** _This only applies to event inputs._
+>
 > #### `replacement`
 >
 > **Type:** `Number`  

--- a/src/lib/processing/events/event-mask.spec.ts
+++ b/src/lib/processing/events/event-mask.spec.ts
@@ -63,6 +63,62 @@ test('EventMaskStep - event array', async(t) => {
 	t.deepEqual(res.getValue(), f32(0, 1, 2, 5, 6, 7, 8));
 });
 
+test('EventMaskStep - event array - keep (array)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: [1, 3] }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32(1, 6, 8));
+});
+
+test('EventMaskStep - event array - keep (array, unordered)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: [3, 1] }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32(1, 6, 8));
+});
+
+test('EventMaskStep - event array - keep (array, negative)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: [1, -1] }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32(1, 2, 6, 8));
+});
+
+test('EventMaskStep - event array - keep (array, negative, too large)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: [10, -1] }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32(2, 8));
+});
+
+test('EventMaskStep - event array - keep (array, negative, too negative)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: [1, -10] }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32(1, 6));
+});
+
+test('EventMaskStep - event array - keep (number)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: 1 }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32(1, 6));
+});
+
+test('EventMaskStep - event array - keep (number, too large)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: 10 }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32());
+});
+
+test('EventMaskStep - event array - keep (number, too negative)', async(t) => {
+	const res = await mockStep(EventMaskStep, [s2Event, e1, e2], { keep: -10 }).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.getValue(), f32());
+});
+
 test('EventMaskStep - VectorSequence', async(t) => {
 	const res = await mockStep(EventMaskStep, [s1, e1, e2]).process();
 	


### PR DESCRIPTION
This PR adds an (optional) option to the `eventMask` step called `keep`. When using the `eventMask` with an event as the input, it allows you to pick certain instances of the event within each cycle.

The instances is selected by supplying an index or an array of indices of the events to pick. 

From the docs:

> #### `keep`
>
> **Type:** `Number | Number array`  
> **Required:** `False`  
> **Default value:** `null`  
>
> An index or an array of indices of events in each cycle to 
> keep. This allows you to keep only a subset of event instances 
> in each cycle.
>
> Negative numbers can be used to count from the end of the cycle, 
> e.g. -1 is the last event in the cycle.
>
> **_Note:_** _This only applies to event inputs._

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Example

``` yaml
- Event: LastLFS
  steps:
    - eventMask: [LFS, RTO, LTO]
      keep: -1
```
_This example shows how to always pick the last LFS event between each cycle of RTO -> LTO._

``` yaml
- Event: FirstAndLastLFS
  steps:
    - eventMask: [LFS, RTO, LTO]
      keep: [1, -1]
```
_This example shows how to always pick both the first and last LFS events between each cycle of RTO -> LTO._

Work item: [AB#21122](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/21122)