### PR TITLE
Add steps for root, sqrt, cbrt, and power (pow)

### DIFF
--- a/docs/nodes/steps/algorithm.md
+++ b/docs/nodes/steps/algorithm.md
@@ -7,7 +7,11 @@
 - [gapFill](#gapfill)
 - [integral](#integral)
 - [negate](#negate)
+- [power / pow](#power)
+- [qbrt](#qbrt)
+- [root](#root)
 - [round](#round)
+- [sqrt](#sqrt)
 
 These are steps that takes a single input (scalar / series / events /
 numbers) and runs a defined algorithmic function over them and outputs 
@@ -306,6 +310,126 @@ Outputs the negated value for each value in the input signal.
 
 ---
 
+### `power`
+
+**Alias:** pow
+
+**Inputs**
+>
+> 1. `Scalar | Series | Event | Number`
+>
+
+**Output:** `Scalar | Series | Event | Number`
+
+**Options**
+>
+> #### `exponent`
+>
+> **Type:** `Number`  
+> **Required:** `False`  
+> **Default value:** `2`  
+>
+> Defines the exponent to raise the input to. If the exponent is
+> omitted, the default value of 2 will be used.
+>
+
+**Shared options**
+>
+> <details><summary>Global options</summary>
+> 
+> The following options are available globally on all steps.
+>
+> * [export](./index.md#export)
+> * [output](./index.md#output)
+> * [set](./index.md#set)
+> * [space](./index.md#space)
+>
+>
+></details>
+>
+
+
+Computes the power of the input signal by raising it to the specified
+exponent. By default, the exponent is 2, which means that the input
+signal is squared.
+
+---
+
+### `qbrt`
+
+**Inputs**
+>
+> 1. `Scalar | Series | Event | Number`
+>
+
+**Output:** `Scalar | Series | Event | Number`
+
+
+**Shared options**
+>
+> <details><summary>Global options</summary>
+> 
+> The following options are available globally on all steps.
+>
+> * [export](./index.md#export)
+> * [output](./index.md#output)
+> * [set](./index.md#set)
+> * [space](./index.md#space)
+>
+>
+></details>
+>
+
+
+Computes the cube root of the input signal.
+
+---
+
+### `root`
+
+**Inputs**
+>
+> 1. `Scalar | Series | Event | Number`
+>
+
+**Output:** `Scalar | Series | Event | Number`
+
+**Options**
+>
+> #### `index`
+>
+> **Type:** `Number`  
+> **Required:** `False`  
+> **Default value:** `2`  
+>
+> Defines the index of the root to take - the nth root of the input.
+> For example, if the index is 2, the square root of the input will
+> be taken. If the index is 3, the cube root of the input will be
+> taken.
+>
+
+**Shared options**
+>
+> <details><summary>Global options</summary>
+> 
+> The following options are available globally on all steps.
+>
+> * [export](./index.md#export)
+> * [output](./index.md#output)
+> * [set](./index.md#set)
+> * [space](./index.md#space)
+>
+>
+></details>
+>
+
+
+Computes the root of the input signal by taking the nth root of the
+input. By default, the index is 2, which means that the square root
+of the input signal is taken.
+
+---
+
 ### `round`
 
 **Inputs**
@@ -357,6 +481,36 @@ given a certain precision:
 * Precision `2`: `1234.57`
 * Precision `3`: `1234.567`
 
+
+---
+
+### `sqrt`
+
+**Inputs**
+>
+> 1. `Scalar | Series | Event | Number`
+>
+
+**Output:** `Scalar | Series | Event | Number`
+
+
+**Shared options**
+>
+> <details><summary>Global options</summary>
+> 
+> The following options are available globally on all steps.
+>
+> * [export](./index.md#export)
+> * [output](./index.md#output)
+> * [set](./index.md#set)
+> * [space](./index.md#space)
+>
+>
+></details>
+>
+
+
+Computes the square root of the input signal.
 
 ---
 

--- a/src/lib/processing/algorithms/power.spec.ts
+++ b/src/lib/processing/algorithms/power.spec.ts
@@ -1,0 +1,47 @@
+import test from 'ava';
+
+import { f32, mockStep } from '../../../test-utils/mock-step';
+import { Signal } from '../../models/signal';
+
+import { PowStep } from './power';
+
+const s1 = new Signal(f32(0, 1, 2, 3, 4), 200);
+
+test('PowStep - handle exponent input', async(t) => {
+	t.is(mockStep(PowStep, [s1]).exponent, 2); 
+	t.is(mockStep(PowStep, [s1], { exponent: 2 }).exponent, 2); 
+	t.is(mockStep(PowStep, [s1], { exponent: 3 }).exponent, 3); 
+	t.is(mockStep(PowStep, [s1], { exponent: 0.5 }).exponent, 0.5); 
+});
+
+test('PowStep - series, default exponent', async(t) => {
+	const step = mockStep(PowStep, [s1]);
+	const result = await step.process();
+	const pow = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(pow), [0, 1, 4, 9, 16]);
+});
+
+test('PowStep - series, exponent 3', async(t) => {
+	const step = mockStep(PowStep, [s1], { exponent: 3 });
+	const result = await step.process();
+	const pow = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(pow), [0, 1, 8, 27, 64]);
+});
+
+test('PowStep - single value, default exponent', async(t) => {
+	const step = mockStep(PowStep, [new Signal(3)]);
+	const result = await step.process();
+	const pow = result.getNumberValue();
+
+	t.deepEqual(pow, 9);
+});
+
+test('PowStep - single value, exponent 4', async(t) => {
+	const step = mockStep(PowStep, [new Signal(3)], { exponent: 4 });
+	const result = await step.process();
+	const pow = result.getNumberValue();
+
+	t.deepEqual(pow, 81);
+});

--- a/src/lib/processing/algorithms/power.ts
+++ b/src/lib/processing/algorithms/power.ts
@@ -1,0 +1,44 @@
+import { PropertyType } from '../../models/property';
+import { StepClass } from '../../step-registry';
+import { markdownFmt } from '../../utils/template-literal-tags';
+
+import { BaseAlgorithmStep } from './base-algorithm';
+
+@StepClass({
+	name: 'power',
+	alias: ['pow'],
+	category: 'Algorithm',
+	description: markdownFmt`
+		Computes the power of the input signal by raising it to the specified
+		exponent. By default, the exponent is 2, which means that the input
+		signal is squared.`,
+	inputs: [
+		{ type: ['Scalar', 'Series', 'Event', 'Number'] },
+	],
+	options: [{
+		name: 'exponent',
+		type: 'Number',
+		required: false,
+		default: '2',
+		description: markdownFmt`
+			Defines the exponent to raise the input to. If the exponent is
+			omitted, the default value of 2 will be used.
+		`,
+	}],
+	output: ['Scalar', 'Series', 'Event', 'Number'],
+})
+export class PowStep extends BaseAlgorithmStep {
+	exponent: number;
+
+	function(a: TypedArray): TypedArray {
+		return a.map(a => Math.pow(a, this.exponent));
+	}
+
+	init() {
+		super.init();
+
+		this.name = 'PowStep';
+
+		this.exponent = this.getPropertyValue<number>('exponent', PropertyType.Number, false) || 2;
+	}
+}

--- a/src/lib/processing/algorithms/root.spec.ts
+++ b/src/lib/processing/algorithms/root.spec.ts
@@ -1,0 +1,112 @@
+import test from 'ava';
+
+import { f32, mockStep } from '../../../test-utils/mock-step';
+import { Signal } from '../../models/signal';
+
+import { QbrtStep, RootStep, SqrtStep } from './root';
+
+const s1 = new Signal(f32(0, 1, 2, 3, 4), 200);
+
+test('RootStep - handle index input', async(t) => {
+	t.is(mockStep(RootStep, [s1]).index, 2); 
+	t.is(mockStep(RootStep, [s1], { index: 2 }).index, 2); 
+	t.is(mockStep(RootStep, [s1], { index: 3 }).index, 3); 
+	t.is(mockStep(RootStep, [s1], { index: 0.5 }).index, 0.5); 
+});
+
+test('RootStep - series, default exponent', async(t) => {
+	const step = mockStep(RootStep, [new Signal(f32(0, 1, 4, 9, 16), 200)]);
+	const result = await step.process();
+	const root = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(root), [0, 1, 2, 3, 4]);
+});
+
+test('RootStep - series, index 3', async(t) => {
+	const step = mockStep(RootStep, [new Signal(f32(0, 1, 8, 27, 64), 200)], { index: 3 });
+	const result = await step.process();
+	const root = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(root), [0, 1, 2, 3, 4]);
+});
+
+test('RootStep - series, index 4', async(t) => {
+	const step = mockStep(RootStep, [new Signal(f32(0, 1, 16, 81, 256), 200)], { index: 4 });
+	const result = await step.process();
+	const root = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(root), [0, 1, 2, 3, 4]);
+});
+
+test('RootStep - single value, default index', async(t) => {
+	const step = mockStep(RootStep, [new Signal(9)]);
+	const result = await step.process();
+	const root = result.getNumberValue();
+
+	t.deepEqual(root, 3);
+});
+
+test('RootStep - single value, index 3', async(t) => {
+	const step = mockStep(RootStep, [new Signal(64)], { index: 3 });
+	const result = await step.process();
+	const root = result.getNumberValue();
+
+	t.deepEqual(root, 4);
+});
+
+test('RootStep - single value, index 6', async(t) => {
+	const step = mockStep(RootStep, [new Signal(64)], { index: 6 });
+	const result = await step.process();
+	const root = result.getNumberValue();
+
+	t.deepEqual(root, 2);
+});
+
+// SqrtStep tests
+test('SqrtStep - check index', async(t) => {
+	t.is(mockStep(SqrtStep, [s1]).index, 2); 
+	t.is(mockStep(SqrtStep, [s1], { index: 2 }).index, 2); 
+	t.is(mockStep(SqrtStep, [s1], { index: 3 }).index, 2); 
+	t.is(mockStep(SqrtStep, [s1], { index: 0.5 }).index, 2); 
+});
+
+test('SqrtStep - series', async(t) => {
+	const step = mockStep(SqrtStep, [new Signal(f32(0, 1, 4, 9, 16), 200)]);
+	const result = await step.process();
+	const root = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(root), [0, 1, 2, 3, 4]);
+});
+
+test('SqrtStep - single value, default index', async(t) => {
+	const step = mockStep(SqrtStep, [new Signal(9)]);
+	const result = await step.process();
+	const root = result.getNumberValue();
+
+	t.deepEqual(root, 3);
+});
+
+
+// QbrtStep tests
+test('QbrtStep - check index', async(t) => {
+	t.is(mockStep(QbrtStep, [s1]).index, 3); 
+	t.is(mockStep(QbrtStep, [s1], { index: 2 }).index, 3); 
+	t.is(mockStep(QbrtStep, [s1], { index: 3 }).index, 3); 
+	t.is(mockStep(QbrtStep, [s1], { index: 0.5 }).index, 3); 
+});
+
+test('QbrtStep - series', async(t) => {
+	const step = mockStep(QbrtStep, [new Signal(f32(0, 1, 8, 27, 64), 200)]);
+	const result = await step.process();
+	const root = result.getFloat32ArrayValue();
+
+	t.deepEqual(Array.from(root), [0, 1, 2, 3, 4]);
+});
+
+test('QbrtStep - single value, default index', async(t) => {
+	const step = mockStep(QbrtStep, [new Signal(27)]);
+	const result = await step.process();
+	const root = result.getNumberValue();
+
+	t.deepEqual(root, 3);
+});

--- a/src/lib/processing/algorithms/root.ts
+++ b/src/lib/processing/algorithms/root.ts
@@ -1,0 +1,94 @@
+import { PropertyType } from '../../models/property';
+import { StepClass } from '../../step-registry';
+import { markdownFmt } from '../../utils/template-literal-tags';
+
+import { BaseAlgorithmStep } from './base-algorithm';
+
+@StepClass({
+	name: 'root',
+	category: 'Algorithm',
+	description: markdownFmt`
+		Computes the root of the input signal by taking the nth root of the
+		input. By default, the index is 2, which means that the square root
+		of the input signal is taken.`,
+	inputs: [
+		{ type: ['Scalar', 'Series', 'Event', 'Number'] },
+	],
+	options: [{
+		name: 'index',
+		type: 'Number',
+		required: false,
+		default: '2',
+		description: markdownFmt`
+			Defines the index of the root to take - the nth root of the input.
+			For example, if the index is 2, the square root of the input will
+			be taken. If the index is 3, the cube root of the input will be
+			taken.
+		`,
+	}],
+	output: ['Scalar', 'Series', 'Event', 'Number'],
+})
+export class RootStep extends BaseAlgorithmStep {
+	index: number;
+
+	function(a: TypedArray): TypedArray {
+		switch (this.index) {
+			case 2:
+				return a.map(a => Math.sqrt(a));
+			case 3:
+				return a.map(a => Math.cbrt(a));
+		}
+
+		return a.map(a => Math.pow(a, 1 / this.index));
+	}
+
+	init() {
+		super.init();
+
+		this.name = 'RootStep';
+
+		this.index = this.getPropertyValue<number>('index', PropertyType.Number, false) || 2;
+	}
+}
+
+@StepClass({
+	name: 'sqrt',
+	category: 'Algorithm',
+	description: markdownFmt`
+		Computes the square root of the input signal.`,
+	inputs: [
+		{ type: ['Scalar', 'Series', 'Event', 'Number'] },
+	],
+	options: [],
+	output: ['Scalar', 'Series', 'Event', 'Number'],
+})
+export class SqrtStep extends RootStep {
+	init() {
+		super.init();
+
+		this.name = 'SqrtStep';
+
+		this.index = 2;
+	}
+}
+
+@StepClass({
+	name: 'qbrt',
+	category: 'Algorithm',
+	description: markdownFmt`
+		Computes the cube root of the input signal.`,
+	inputs: [
+		{ type: ['Scalar', 'Series', 'Event', 'Number'] },
+	],
+	options: [],
+	output: ['Scalar', 'Series', 'Event', 'Number'],
+})
+export class QbrtStep extends RootStep {
+	init() {
+		super.init();
+
+		this.name = 'QbrtStep';
+
+		this.index = 3;
+	}
+}

--- a/src/lib/processing/index.ts
+++ b/src/lib/processing/index.ts
@@ -92,6 +92,8 @@ export * from './algorithms/diff';
 export * from './algorithms/filter';
 export * from './algorithms/gap-fill';
 export * from './algorithms/negate';
+export * from './algorithms/power';
+export * from './algorithms/root';
 export * from './algorithms/round';
 export * from './algorithms/trigonometry';
 export * from './algorithms/integral';


### PR DESCRIPTION
Adds `root`, `sqrt`, `cbrt`, and `power` (alias `pow`) steps.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Example

``` yaml
- parameter: hypotenuse
  steps:
    - pow: 2
      output: a
    - pow: 3
      output: b
    - add: [a, b]
    - sqrt: $prev
```

Work item: [AB#31677](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/31677)