### PR TITLE
Arithmetic with scalars

### DIFF
--- a/src/lib/processing/arithmetic.spec.ts
+++ b/src/lib/processing/arithmetic.spec.ts
@@ -4,7 +4,7 @@ import { f32, i32, mockStep } from '../../test-utils/mock-step';
 import { Segment } from '../models/segment';
 import { QuaternionSequence } from '../models/sequence/quaternion-sequence';
 import { VectorSequence } from '../models/sequence/vector-sequence';
-import { Signal } from '../models/signal';
+import { Signal, SignalType } from '../models/signal';
 
 import { AdditionStep, DivisionStep, FrameSequenceOperandOrder, MultiplyStep, SubtractionStep } from './arithmetic';
 
@@ -90,6 +90,16 @@ test('Arithmetic - AdditionStep (VectorSequence)', async(t) => {
 	for (const component of res.components) {
 		t.deepEqual(f32(...res.getComponent(component)), f32(2, 4, 6));
 	}
+});
+
+test('Arithmetic - AdditionStep (numbers)', async(t) => {
+	const n1 = new Signal(1);
+	const n2 = new Signal(2);
+	const step = mockStep(AdditionStep, [n1, n2]);
+	const res = await step.process();
+
+	t.is(res.type, SignalType.Float32);
+	t.is(res.getValue(), 3);
 });
 
 // Test operand sequence.

--- a/src/lib/processing/arithmetic.ts
+++ b/src/lib/processing/arithmetic.ts
@@ -9,6 +9,7 @@ import { ProcessingError } from '../utils/processing-error';
 import { getReferenceSignal } from '../utils/reference-signal';
 import { SequenceUtil } from '../utils/sequence';
 import { markdownFmt } from '../utils/template-literal-tags';
+import { TypeCheck } from '../utils/type-check';
 
 import { BaseStep } from './base-step';
 
@@ -185,6 +186,15 @@ export class BaseArithmeticStep extends BaseStep {
 			const originalType = referenceInput.type;
 
 			switch (originalType) {
+				case SignalType.Float32: {
+					if (TypeCheck.isArrayLike(res) && res.length === 1) {
+						out.setValue(res[0]);
+						break;
+					}
+
+					out.setValue(res);
+					break;
+				}
 				case SignalType.VectorSequence:
 					out.setValue(Marker.fromArray(referenceInput.name, res as TypedArray[]));
 					break;

--- a/src/lib/utils/type-check.ts
+++ b/src/lib/utils/type-check.ts
@@ -6,7 +6,7 @@ export class TypeCheck {
 	 * Returns true if the value is a JavaScript Array. 
 	 * @param value 
 	 */
-	static isArray(value) {
+	static isArray(value): value is number[] {
 		return Array.isArray(value);
 	}
 
@@ -14,7 +14,7 @@ export class TypeCheck {
 	 * Returns true if the value is a typed array.
 	 * @param value 
 	 */
-	static isTypedArray(value) {
+	static isTypedArray(value): value is TypedArray {
 		return isTypedArray(value);
 	}
 


### PR DESCRIPTION
Previously, any arithmetic steps with two scalar input values returned a scalar result wrapped in an array. This fixes the issue so that the result also is scalar.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [N/A] Documentation added

### Example
Show example in yaml file...

``` yaml
- parameter: test
  steps:
    - add: [5, 3] # returned `[8]`, will now return `8`
```

Work item: [AB#31988](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/31988)