### PR TITLE
If step: using dot notation in input name

### DIFF
--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -168,6 +168,16 @@ test('IfStep (mock) - Mixed input, simple - then', async(t) => {
 	t.is(res.getValue(), 10);
 });
 
+test('IfStep (mock) - Operands with special characters - dot', async(t) => {
+	const step = mockStep(IfStep, [s1, s1], {
+		then: [s10],
+		else: [s0],
+	}, '2 > MyValue.x');
+
+	const res = await step.process();
+	t.is(res.getValue(), 10);
+});
+
 test('IfStep (mock) - One input, check existing values - else', async(t) => {
 	const step = mockStep(IfStep, [sArray4], {
 		then: [s2],

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -1,4 +1,5 @@
 import { evaluateExpression, parseExpression, printExpression, tokenizeExpression } from 'expression-engine';
+import { set } from 'lodash';
 
 import { Signal, SignalType } from '../models/signal';
 import { StepCategory, StepClass } from '../step-registry';
@@ -119,7 +120,7 @@ export class IfStep extends BaseStep {
 
 		for (let i = 0; i < operands.length; i++) {
 			if (!NumberUtil.isNumeric(operands[i])) {
-				expressionValues[operands[i]] = this.getValueForInput(i);
+				set(expressionValues, operands[i], this.getValueForInput(i));
 			}
 		}
 


### PR DESCRIPTION
Fixes an issue when parsing an expression in the `if` step where any of the operands contains a dot, like selecting a component, for example.

### Checklist
- [X] Test case implemented
- [X] Test coverage 100%
- [X] Tested inside a yaml pipeline
- [N/A] Documentation added

### Example

``` yaml
- parameter: OptionsTest
  steps:
    - import: Hips@1
      export: fisrtHips
    - if: bHips.x < 2000
      then: 100
      else: 200
```

Work item: [AB#31973](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/31973)