### PR TITLE
If step improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,14 @@
         "ignoreCase": true
       }
     ],
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
     "@typescript-eslint/no-extra-semi": "off",
 	"no-multiple-empty-lines": [
 		"error",

--- a/docs/nodes/steps/logic.md
+++ b/docs/nodes/steps/logic.md
@@ -58,9 +58,32 @@ The following operators are supported:
 
 Parentheses can be used to influence the order of evaluation.
 
-Only numbers and single-element arrays can be part of operands in the
-expression. In addition, a single input can be used to check for existence 
-of values.
+You are able to use "functions" in the expression to validate if a 
+signal is empty or exists. The following functions are supported:
+
+* `empty(signalName)` - Returns true if the signal is empty, 
+i.e. the signal does not exist or the value is falsy 
+(false, null, NaN, empty string).
+* `exists(signalName)` - Returns true if the signal exists, 
+i.e. the signal is _defined_. This function does not validate 
+the _value_ of the signal but _only_ if the signal is defined 
+or not. The signal value could be falsy, but as long as the 
+signal is defined, this function will return true.
+
+***Note:** Due to the way YAML is parsed, you must wrap expressions
+beginning with an exclamation mark in quotes, e.g. `"!empty(mySignal)"`.*
+
+***Note:** In order to be able to evaluate missing signals, this 
+step does not validate the inputs to the expression. To validate 
+a signal's existence, use the `exists` function.*
+
+***Note:** The validation of the inputs to the `then` and `else` 
+options are deferred until they are needed. This means that if the 
+expression evaluates to true, but the `then` option is missing, 
+the step will not fail until the `then` option is needed. This is 
+done to allow for the use of references to signals that may only be 
+able to be resolved in certain circumstances, e.g. when the 
+expression evaluates to true.*
 
 ## Examples
 
@@ -85,8 +108,34 @@ signal. If `mySignal` has values, the resulting signal would be `mySignal`, othe
 the result is `myDefault`.
 
 ``` yaml
-- if: mySignal
+- if: "!empty(mySignal)"
   then: mySignal
+  else: myDefault
+```
+
+The following example shows how you can check for the existence of of a
+signal. If `mySignal` exists, the resulting signal would be `mySignal`, 
+otherwise the result is `myDefault`.
+
+``` yaml
+- if: exists(mySignal)
+  then: mySignal
+  else: myDefault
+```
+
+The following example shows how you can compare values from measurement fields.
+
+``` yaml
+- if: $field(My Field, measurement, numeric) > $field(My Other Field, measurement, numeric)
+  then: mySignal
+  else: myDefault
+```
+
+The following example shows how to return a field value if it is not empty, otherwise return a default value.
+
+``` yaml
+- if: "!empty($field(My Field, measurement, numeric))"
+  then: $field(My Field, measurement, numeric)
   else: myDefault
 ```
 

--- a/docs/nodes/steps/logic.md
+++ b/docs/nodes/steps/logic.md
@@ -62,8 +62,9 @@ You are able to use "functions" in the expression to validate if a
 signal is empty or exists. The following functions are supported:
 
 * `empty(signalName)` - Returns true if the signal is empty, 
-i.e. the signal does not exist or the value is falsy 
-(false, null, NaN, empty string).
+i.e. the signal does not exist or the value is falsy but not zero
+(false, null, NaN, empty string). The value zero (0) is not
+considered empty because it is a valid value for a signal.
 * `exists(signalName)` - Returns true if the signal exists, 
 i.e. the signal is _defined_. This function does not validate 
 the _value_ of the signal but _only_ if the signal is defined 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/parser": "^5.27.0",
+        "base-64": "^1.0.0",
         "cubic-spline": "^3.0.3",
         "expression-engine": "^1.8.1",
         "fili": "^2.0.3",
@@ -1929,6 +1930,12 @@
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha1-CdDyCE4yo/0IwkdblzeI7uauj0o=",
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2094,9 +2101,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha1-6rDg85Leb3QRdR0Ujem1vWsgPkY=",
+      "version": "1.0.30001564",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
+      "integrity": "sha1-6qi7xYwMvM3Le0EYbfOd0rpZGIk=",
       "dev": true,
       "funding": [
         {
@@ -9515,6 +9522,11 @@
       "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
     },
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha1-CdDyCE4yo/0IwkdblzeI7uauj0o="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -9623,9 +9635,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha1-6rDg85Leb3QRdR0Ujem1vWsgPkY=",
+      "version": "1.0.30001564",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
+      "integrity": "sha1-6qi7xYwMvM3Le0EYbfOd0rpZGIk=",
       "dev": true
     },
     "cbor": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@typescript-eslint/parser": "^5.27.0",
+    "base-64": "^1.0.0",
     "cubic-spline": "^3.0.3",
     "expression-engine": "^1.8.1",
     "fili": "^2.0.3",

--- a/src/lib/models/property.ts
+++ b/src/lib/models/property.ts
@@ -80,7 +80,7 @@ export class Property {
 	 */
 	static validateSignalTypes(signals: Signal[], propertyTypes: PropertyType | PropertyType[]): boolean {
 		for (const signal of signals) {
-			if (!Property.validateSignalType(signal.type, propertyTypes)) {
+			if (!Property.validateSignalType(signal?.type, propertyTypes)) {
 				return false;
 			}
 		}

--- a/src/lib/processing/base-step.ts
+++ b/src/lib/processing/base-step.ts
@@ -72,10 +72,10 @@ export class BaseStep {
 					if (expectedTypes.length === 1 && expectedTypes[0] === PropertyType.Number) {
 						const convertedSignals = [];
 						for (const signal of optionSignals) {
-							if (signal.type === SignalType.Float32) {
+							if (signal?.type === SignalType.Float32) {
 								convertedSignals.push(signal);
 							}
-							else if (signal.type === SignalType.Float32Array && signal.length === 1) {
+							else if (signal?.type === SignalType.Float32Array && signal.length === 1) {
 								const value = signal.clone(signal.getValue()[0]);
 								convertedSignals.push(value);
 							}

--- a/src/lib/processing/base-step.ts
+++ b/src/lib/processing/base-step.ts
@@ -10,6 +10,8 @@ import { Space } from './space';
  * Base class for running processing steps.
  */
 export class BaseStep {
+	static acceptsMissingInputs = false;
+
 	name: string;
 	space: Space;
 	inputs: Signal[];

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -194,13 +194,43 @@ test('IfStep (mock) - Mixed input, simple - then', async(t) => {
 });
 
 test('IfStep (mock) - Operands with special characters - dot', async(t) => {
-	const step = mockStep(IfStep, [s1, s1], {
+	const step = mockStep(IfStep, [new Signal(2), s1], {
 		then: [s10],
 		else: [s0],
 	}, '2 > MyValue.x');
 
 	const res = await step.process();
 	t.is(res.getValue(), 10);
+});
+
+test.only('IfStep (mock) - Operands with spaces', async(t) => {
+	const positive1 = await mockStep(IfStep, 
+		[s2, s1], { then: [s10], else: [s0] }, 
+		'2 > My Special Value'
+	).process();
+
+	t.is(positive1.getValue(), 10);
+
+	const positive2 = await mockStep(IfStep, 
+		[s1, s1], { then: [s10], else: [s0] }, 
+		'My Special Value == My Special Value'
+	).process();
+
+	t.is(positive2.getValue(), 10);
+
+	const negative1 = await mockStep(IfStep, 
+		[s2, s1], { then: [s10], else: [s0] }, 
+		'2 < My Special Value'
+	).process();
+
+	t.is(negative1.getValue(), 0);
+
+	const negative2 = await mockStep(IfStep, 
+		[s1, s1], { then: [s10], else: [s0] }, 
+		'My Special Value < My Special Value'
+	).process();
+
+	t.is(negative2.getValue(), 0);
 });
 
 test('IfStep (mock) - One input, check existing values - else', async(t) => {

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -495,3 +495,61 @@ test('IfStep (mock) - One input, function - empty', async(t) => {
 
 	t.is(negative3.getValue(), 10);
 });
+
+test('IfStep (mock) - field variable', async(t) => {
+	const positive1 = await mockStep(IfStep, 
+		[new Signal(3)], { then: [s2], else: [s10] }, 
+		'$field(MyValue, My Measurement, numeric) > 2'
+	).process();
+
+	t.is(positive1.getValue(), 2);
+
+	const positive2 = await mockStep(IfStep, 
+		[new Signal(1)], { then: [s2], else: [s10] }, 
+		'exists($field(MyValue, My Measurement, numeric))'
+	).process();
+
+	t.is(positive2.getValue(), 2);
+
+	const positive3 = await mockStep(IfStep, 
+		[new Signal(f32(NaN))], { then: [s2], else: [s10] }, 
+		'empty($field(MyValue, My Measurement, numeric))'
+	).process();
+
+	t.is(positive3.getValue(), 2);
+
+	const positive4 = await mockStep(IfStep, 
+		[new Signal(f32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'!empty($field(MyValue, My Measurement, numeric))'
+	).process();
+
+	t.is(positive4.getValue(), 2);
+
+	const negative1 = await mockStep(IfStep, 
+		[new Signal(1)], { then: [s2], else: [s10] }, 
+		'$field(MyValue, My Measurement, numeric) > 2'
+	).process();
+
+	t.is(negative1.getValue(), 10);
+
+	const negative2 = await mockStep(IfStep, 
+		[undefined], { then: [s2], else: [s10] }, 
+		'exists($field(MyValue, My Measurement, numeric))'
+	).process();
+
+	t.is(negative2.getValue(), 10);
+
+	const negative3 = await mockStep(IfStep, 
+		[new Signal(f32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'empty($field(MyValue, My Measurement, numeric))'
+	).process();
+
+	t.is(negative3.getValue(), 10);
+
+	const negative4 = await mockStep(IfStep, 
+		[new Signal(f32(NaN))], { then: [s2], else: [s10] }, 
+		'!empty($field(MyValue, My Measurement, numeric))'
+	).process();
+
+	t.is(negative4.getValue(), 10);
+});

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -269,7 +269,7 @@ test('IfStep (mock) - Mixed input, simple - then', async(t) => {
 	t.is(res.getValue(), 10);
 });
 
-test('IfStep (mock) - Operands with special characters - dot', async(t) => {
+test('IfStep (mock) - Operands with special characters - dot - then', async(t) => {
 	const step = mockStep(IfStep, [new Signal(2), s1], {
 		then: [s10],
 		else: [s0],
@@ -277,6 +277,56 @@ test('IfStep (mock) - Operands with special characters - dot', async(t) => {
 
 	const res = await step.process();
 	t.is(res.getValue(), 10);
+});
+
+test('IfStep (mock) - Operands with special characters - dot - else', async(t) => {
+	const step = mockStep(IfStep, [new Signal(2), s10], {
+		then: [s10],
+		else: [s0],
+	}, '2 > MyValue.x');
+
+	const res = await step.process();
+	t.is(res.getValue(), 0);
+});
+
+test.only('IfStep (mock) - Operands with special characters - @ - then', async(t) => {
+	const step = mockStep(IfStep, [new Signal(2), s1], {
+		then: [s10],
+		else: [s0],
+	}, '2 > MyValue@MyEvent');
+
+	const res = await step.process();
+	t.is(res.getValue(), 10);
+});
+
+test.only('IfStep (mock) - Operands with special characters - @ - else', async(t) => {
+	const step = mockStep(IfStep, [new Signal(2), s10], {
+		then: [s10],
+		else: [s0],
+	}, '2 > MyValue@MyEvent');
+
+	const res = await step.process();
+	t.is(res.getValue(), 0);
+});
+
+test.only('IfStep (mock) - Operands with special characters - dot and @ - then', async(t) => {
+	const step = mockStep(IfStep, [new Signal(2), s1], {
+		then: [s10],
+		else: [s0],
+	}, '2 > MyValue.x@MyEvent');
+
+	const res = await step.process();
+	t.is(res.getValue(), 10);
+});
+
+test.only('IfStep (mock) - Operands with special characters - dot and @ - else', async(t) => {
+	const step = mockStep(IfStep, [new Signal(2), s10], {
+		then: [s10],
+		else: [s0],
+	}, '2 > MyValue.x@MyEvent');
+
+	const res = await step.process();
+	t.is(res.getValue(), 0);
 });
 
 test('IfStep (mock) - Operands with spaces', async(t) => {

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -44,6 +44,82 @@ test('IfStep (mock) - Missing "else"', async(t) => {
 	await t.throwsAsync(step.process());
 });
 
+test('IfStep (mock) - String then', async(t) => {
+	// Not a problem if the 'then' is empty, as long as the then is not and is chosen.
+	const step1 = mockStep(IfStep, [s1, s2], {
+		then: [new Signal('test')],
+		else: [s10],
+	}, '1 > 2');
+
+	const res1 = await step1.process();
+	t.is(res1.getValue(), 10);
+
+	// If the empty 'then' is chosen, it's a problem.
+	const step2 = mockStep(IfStep, [s1, s2], {
+		then: [new Signal('test')],
+		else: [s10],
+	}, '1 < 2');
+
+	await t.throwsAsync(step2.process());
+});
+
+test('IfStep (mock) - String else', async(t) => {
+	// Not a problem if the 'then' is empty, as long as the then is not and is chosen.
+	const step1 = mockStep(IfStep, [s1, s2], {
+		then: [s10],
+		else: [new Signal('test')],
+	}, '1 < 2');
+
+	const res1 = await step1.process();
+	t.is(res1.getValue(), 10);
+
+	// If the empty 'then' is chosen, it's a problem.
+	const step2 = mockStep(IfStep, [s1, s2], {
+		then: [s10],
+		else: [new Signal('test')],
+	}, '1 > 2');
+
+	await t.throwsAsync(step2.process());
+});
+
+test('IfStep (mock) - Empty else', async(t) => {
+	// Not a problem if the 'else' is empty, as long as the then is not and is chosen.
+	const step1 = mockStep(IfStep, [s1, s2], {
+		then: [s10],
+		else: [undefined],
+	}, '1 < 2');
+
+	const res1 = await step1.process();
+	t.is(res1.getValue(), 10);
+
+	// If the empty 'else' is chosen, it's a problem.
+	const step2 = mockStep(IfStep, [s1, s2], {
+		then: [s10],
+		else: [undefined],
+	}, '1 > 2');
+
+	await t.throwsAsync(step2.process());
+});
+
+test('IfStep (mock) - Empty then', async(t) => {
+	// Not a problem if the 'then' is empty, as long as the then is not and is chosen.
+	const step1 = mockStep(IfStep, [s1, s2], {
+		then: [undefined],
+		else: [s10],
+	}, '1 > 2');
+
+	const res1 = await step1.process();
+	t.is(res1.getValue(), 10);
+
+	// If the empty 'then' is chosen, it's a problem.
+	const step2 = mockStep(IfStep, [s1, s2], {
+		then: [undefined],
+		else: [s10],
+	}, '1 < 2');
+
+	await t.throwsAsync(step2.process());
+});
+
 test('IfStep (mock) - More than one input to "then" option', async(t) => {
 	const step = mockStep(IfStep, [s1, s2], {
 		then: [s1, s2],
@@ -203,7 +279,7 @@ test('IfStep (mock) - Operands with special characters - dot', async(t) => {
 	t.is(res.getValue(), 10);
 });
 
-test.only('IfStep (mock) - Operands with spaces', async(t) => {
+test('IfStep (mock) - Operands with spaces', async(t) => {
 	const positive1 = await mockStep(IfStep, 
 		[s2, s1], { then: [s10], else: [s0] }, 
 		'2 > My Special Value'

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -553,3 +553,76 @@ test('IfStep (mock) - field variable', async(t) => {
 
 	t.is(negative4.getValue(), 10);
 });
+
+test('IfStep (mock) - $prev variable', async(t) => {
+	const positive1 = await mockStep(IfStep, 
+		[new Signal(3)], { then: [s2], else: [s10] }, 
+		'$prev > 2'
+	).process();
+
+	t.is(positive1.getValue(), 2);
+
+	const positive2 = await mockStep(IfStep, 
+		[new Signal(3)], { then: [s2], else: [s10] }, 
+		'$prev(2) > 2'
+	).process();
+
+	t.is(positive2.getValue(), 2);
+
+	const positive3 = await mockStep(IfStep, 
+		[new Signal(1)], { then: [s2], else: [s10] }, 
+		'exists($prev(2))'
+	).process();
+
+	t.is(positive3.getValue(), 2);
+
+	const positive4 = await mockStep(IfStep, 
+		[new Signal(f32(NaN))], { then: [s2], else: [s10] }, 
+		'empty($prev(2))'
+	).process();
+
+	t.is(positive4.getValue(), 2);
+
+	const positive5 = await mockStep(IfStep, 
+		[new Signal(f32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'!empty($prev(2))'
+	).process();
+
+	t.is(positive5.getValue(), 2);
+
+
+	const negative1 = await mockStep(IfStep, 
+		[new Signal(1)], { then: [s2], else: [s10] }, 
+		'$prev > 2'
+	).process();
+
+	t.is(negative1.getValue(), 10);
+
+	const negative2 = await mockStep(IfStep, 
+		[new Signal(1)], { then: [s2], else: [s10] }, 
+		'$prev > 2'
+	).process();
+
+	t.is(negative2.getValue(), 10);
+
+	const negative3 = await mockStep(IfStep, 
+		[undefined], { then: [s2], else: [s10] }, 
+		'exists($prev(2))'
+	).process();
+
+	t.is(negative3.getValue(), 10);
+
+	const negative4 = await mockStep(IfStep, 
+		[new Signal(f32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'empty($prev(2))'
+	).process();
+
+	t.is(negative4.getValue(), 10);
+
+	const negative5 = await mockStep(IfStep, 
+		[new Signal(f32(NaN))], { then: [s2], else: [s10] }, 
+		'!empty($prev(2))'
+	).process();
+
+	t.is(negative5.getValue(), 10);
+});

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -1,9 +1,13 @@
 import test from 'ava';
 
 import { f32, i32, mockStep } from '../../test-utils/mock-step';
+import { Segment } from '../models/segment';
+import { QuaternionSequence } from '../models/sequence/quaternion-sequence';
+import { VectorSequence } from '../models/sequence/vector-sequence';
 import { Signal } from '../models/signal';
 
 import { IfStep } from './logic';
+
 
 /**
  * This test is testing the input parsing of the mockStep function.
@@ -20,6 +24,9 @@ const sArray2 = new Signal(f32(3));
 const sArray3 = new Signal(i32(1));
 const sArray4 = new Signal(i32());
 const sString = new Signal('test');
+
+const segment1 = new Signal(new Segment('test 1', new VectorSequence(f32(1, 2, 3), f32(2, 2, 2), f32(6, 5, 4)), new QuaternionSequence(f32(1, 2, 3), f32(1, 2, 3), f32(1, 2, 3), f32(1, 2, 3))));
+
 
 test('IfStep (mock) - Missing "then"', async(t) => {
 	const step = mockStep(IfStep, [s1, s2], {
@@ -73,20 +80,20 @@ test('IfStep (mock) - Bad parentheses', async(t) => {
 	await t.throwsAsync(step.process());
 });
 
-test('IfStep (mock) - Unsupported type - array with length > 1', async(t) => {
-	const step = mockStep(IfStep, [sArray, s1], {
+test('IfStep (mock) - Unsupported comparison - string and number', async(t) => {
+	const step = mockStep(IfStep, [sString], {
 		then: [s10],
 		else: [s0],
-	}, 'MyArray > 1');
+	}, 'MyString > 1');
 
 	await t.throwsAsync(step.process());
 });
 
-test('IfStep (mock) - Unsupported type - string', async(t) => {
-	const step = mockStep(IfStep, [sString, s1], {
+test('IfStep (mock) - Unsupported type - segment', async(t) => {
+	const step = mockStep(IfStep, [segment1], {
 		then: [s10],
 		else: [s0],
-	}, 'MyString > 1');
+	}, 'MySegment > 1');
 
 	await t.throwsAsync(step.process());
 });
@@ -113,6 +120,24 @@ test('IfStep (mock) - Array of length 1 support', async(t) => {
 		then: [s10],
 		else: [s0],
 	}, 'MyShortArray != 1');
+
+	const res2 = await step2.process();
+	t.is(res2.getValue(), 0);
+});
+
+test('IfStep (mock) - Array of length n support', async(t) => {
+	const step1 = mockStep(IfStep, [sArray, s1], {
+		then: [s10],
+		else: [s0],
+	}, 'MyShortArray != 1');
+
+	const res1 = await step1.process();
+	t.is(res1.getValue(), 10);
+
+	const step2 = mockStep(IfStep, [sArray, s1], {
+		then: [s10],
+		else: [s0],
+	}, 'MyShortArray != 3');
 
 	const res2 = await step2.process();
 	t.is(res2.getValue(), 0);
@@ -188,22 +213,169 @@ test('IfStep (mock) - One input, check existing values - then', async(t) => {
 	t.is(res.getValue(), 2);
 });
 
-test('IfStep (mock) - One input, check for NaN - else', async(t) => {
-	const step = mockStep(IfStep, [sNaN], {
+test('IfStep (mock) - One input - else', async(t) => {
+	const step1 = mockStep(IfStep, [sNaN], {
 		then: [s2],
 		else: [s10],
 	}, 'MyValue');
 
-	const res = await step.process();
-	t.is(res.getValue(), 10);
+	const res1 = await step1.process();
+	t.is(res1.getValue(), 10);
+
+	const step2 = mockStep(IfStep, [s0], {
+		then: [s2],
+		else: [s10],
+	}, 'MyValue');
+
+	const res2 = await step2.process();
+	t.is(res2.getValue(), 10);
 });
 
-test('IfStep (mock) - One input, check for NaN - then', async(t) => {
-	const step = mockStep(IfStep, [s0], {
+test('IfStep (mock) - One input, int array (3)', async(t) => {
+	const positive = await mockStep(IfStep, [new Signal(i32(1, 2, 3))], { 
+		then: [s2],
+		else: [s10], 
+	}, 'MyValue').process();
+
+	t.is(positive.getValue(), 2);
+
+	const negative = await mockStep(IfStep, [new Signal(i32(1, 2, 3))], { 
+		then: [s2],
+		else: [s10], 
+	}, '!MyValue').process();
+	
+	t.is(negative.getValue(), 10);
+});
+
+test('IfStep (mock) - One input, inverted', async(t) => {
+	const positive = await mockStep(IfStep, [undefined], { 
+		then: [s2],
+		else: [s10], 
+	}, '!a').process();
+
+	t.is(positive.getValue(), 2);
+
+	const negative = await mockStep(IfStep, [s1], { 
+		then: [s2],
+		else: [s10], 
+	}, '!a').process();
+
+	t.is(negative.getValue(), 10);
+});
+
+test('IfStep (mock) - One input - int array (1)', async(t) => {
+	const step = mockStep(IfStep, [new Signal(i32(1, 2, 3))], {
 		then: [s2],
 		else: [s10],
 	}, 'MyValue');
-
+	
 	const res = await step.process();
 	t.is(res.getValue(), 2);
+});
+
+test('IfStep (mock) - One input - float array', async(t) => {
+	const step = mockStep(IfStep, [new Signal(i32(1, 2, 3))], {
+		then: [s2],
+		else: [s10],
+	}, 'MyValue');
+	
+	const res = await step.process();
+	t.is(res.getValue(), 2);
+});
+
+test('IfStep (mock) - One input, function - exists', async(t) => {
+	const positive = await mockStep(IfStep, 
+		[new Signal(i32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'exists(MyValue)'
+	).process();
+
+	t.is(positive.getValue(), 2);
+
+	const negative = await mockStep(IfStep, 
+		[undefined], { then: [s2], else: [s10] }, 
+		'exists(MyValue)'
+	).process();
+
+	t.is(negative.getValue(), 10);
+});
+
+test('IfStep (mock) - Two inputs, function - exists', async(t) => {
+	const positive = await mockStep(IfStep, 
+		[new Signal(i32(1, 2, 3)), new Signal(5)], { then: [s2], else: [s10] }, 
+		'exists(MyValue) && exists(MyValue2)'
+	).process();
+
+	t.is(positive.getValue(), 2);
+
+	const negative1 = await mockStep(IfStep, 
+		[undefined, new Signal(i32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'exists(MyValue) && exists(MyValue2)'
+	).process();
+
+	t.is(negative1.getValue(), 10);
+
+	const negative2 = await mockStep(IfStep, 
+		[new Signal(i32(1, 2, 3)), undefined], { then: [s2], else: [s10] }, 
+		'exists(MyValue) && exists(MyValue2)'
+	).process();
+
+	t.is(negative2.getValue(), 10);
+});
+
+test('IfStep (mock) - One input, function - empty', async(t) => {
+	const positive1 = await mockStep(IfStep, 
+		[new Signal(0)], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(positive1.getValue(), 2);
+
+	const positive2 = await mockStep(IfStep, 
+		[new Signal(undefined)], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(positive2.getValue(), 2);
+
+	const positive3 = await mockStep(IfStep, 
+		[undefined], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(positive3.getValue(), 2);
+
+	const positive4 = await mockStep(IfStep, 
+		[new Signal(f32(NaN))], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(positive4.getValue(), 2);
+
+	const positive5 = await mockStep(IfStep, 
+		[new Signal(f32(NaN, NaN, NaN, NaN))], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(positive5.getValue(), 2);
+
+	const negative1 = await mockStep(IfStep, 
+		[new Signal(1)], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(negative1.getValue(), 10);
+
+	const negative2 = await mockStep(IfStep, 
+		[new Signal(f32(1, 2, 3))], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(negative2.getValue(), 10);
+
+	const negative3 = await mockStep(IfStep, 
+		[new Signal('Hello world')], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(negative3.getValue(), 10);
 });

--- a/src/lib/processing/logic.spec.ts
+++ b/src/lib/processing/logic.spec.ts
@@ -289,7 +289,7 @@ test('IfStep (mock) - Operands with special characters - dot - else', async(t) =
 	t.is(res.getValue(), 0);
 });
 
-test.only('IfStep (mock) - Operands with special characters - @ - then', async(t) => {
+test('IfStep (mock) - Operands with special characters - @ - then', async(t) => {
 	const step = mockStep(IfStep, [new Signal(2), s1], {
 		then: [s10],
 		else: [s0],
@@ -299,7 +299,7 @@ test.only('IfStep (mock) - Operands with special characters - @ - then', async(t
 	t.is(res.getValue(), 10);
 });
 
-test.only('IfStep (mock) - Operands with special characters - @ - else', async(t) => {
+test('IfStep (mock) - Operands with special characters - @ - else', async(t) => {
 	const step = mockStep(IfStep, [new Signal(2), s10], {
 		then: [s10],
 		else: [s0],
@@ -309,7 +309,7 @@ test.only('IfStep (mock) - Operands with special characters - @ - else', async(t
 	t.is(res.getValue(), 0);
 });
 
-test.only('IfStep (mock) - Operands with special characters - dot and @ - then', async(t) => {
+test('IfStep (mock) - Operands with special characters - dot and @ - then', async(t) => {
 	const step = mockStep(IfStep, [new Signal(2), s1], {
 		then: [s10],
 		else: [s0],
@@ -319,7 +319,7 @@ test.only('IfStep (mock) - Operands with special characters - dot and @ - then',
 	t.is(res.getValue(), 10);
 });
 
-test.only('IfStep (mock) - Operands with special characters - dot and @ - else', async(t) => {
+test('IfStep (mock) - Operands with special characters - dot and @ - else', async(t) => {
 	const step = mockStep(IfStep, [new Signal(2), s10], {
 		then: [s10],
 		else: [s0],
@@ -457,6 +457,7 @@ test('IfStep (mock) - One input, function - exists', async(t) => {
 
 	t.is(positive.getValue(), 2);
 
+
 	const negative = await mockStep(IfStep, 
 		[undefined], { then: [s2], else: [s10] }, 
 		'exists(MyValue)'
@@ -489,9 +490,10 @@ test('IfStep (mock) - Two inputs, function - exists', async(t) => {
 });
 
 test('IfStep (mock) - One input, function - empty', async(t) => {
+	// 0 is not empty
 	const positive1 = await mockStep(IfStep, 
 		[new Signal(0)], { then: [s2], else: [s10] }, 
-		'empty(MyValue)'
+		'!empty(MyValue)'
 	).process();
 
 	t.is(positive1.getValue(), 2);
@@ -544,6 +546,22 @@ test('IfStep (mock) - One input, function - empty', async(t) => {
 	).process();
 
 	t.is(negative3.getValue(), 10);
+
+	// 0 is not empty
+	const negative4 = await mockStep(IfStep, 
+		[new Signal(0)], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(negative4.getValue(), 10);
+
+	// 0 is not empty
+	const negative5 = await mockStep(IfStep, 
+		[new Signal(f32(0, 1, 2, 3))], { then: [s2], else: [s10] }, 
+		'empty(MyValue)'
+	).process();
+
+	t.is(negative5.getValue(), 10);
 });
 
 test('IfStep (mock) - field variable', async(t) => {
@@ -640,6 +658,14 @@ test('IfStep (mock) - $prev variable', async(t) => {
 
 	t.is(positive5.getValue(), 2);
 
+	// 0 is not empty
+	const positive6 = await mockStep(IfStep, 
+		[new Signal(f32(0))], { then: [s2], else: [s10] }, 
+		'!empty($prev(2))'
+	).process();
+
+	t.is(positive6.getValue(), 2);
+
 
 	const negative1 = await mockStep(IfStep, 
 		[new Signal(1)], { then: [s2], else: [s10] }, 
@@ -675,4 +701,12 @@ test('IfStep (mock) - $prev variable', async(t) => {
 	).process();
 
 	t.is(negative5.getValue(), 10);
+
+	// 0 is not empty
+	const negative6 = await mockStep(IfStep, 
+		[new Signal(f32(0))], { then: [s2], else: [s10] }, 
+		'empty($prev(2))'
+	).process();
+
+	t.is(negative6.getValue(), 10);
 });

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -34,8 +34,9 @@ import { BaseStep } from './base-step';
 		signal is empty or exists. The following functions are supported:
 
 		* ''empty(signalName)'' - Returns true if the signal is empty, 
-		i.e. the signal does not exist or the value is falsy 
-		(false, null, NaN, empty string).
+		i.e. the signal does not exist or the value is falsy but not zero
+		(false, null, NaN, empty string). The value zero (0) is not
+		considered empty because it is a valid value for a signal.
 		* ''exists(signalName)'' - Returns true if the signal exists, 
 		i.e. the signal is _defined_. This function does not validate 
 		the _value_ of the signal but _only_ if the signal is defined 
@@ -169,7 +170,13 @@ export class IfStep extends BaseStep {
 				}
 
 				if (operand.empty) {
-					value = !value;
+					// Zeroes are not considered empty.
+					if (value === 0) {
+						value = false;
+					}
+					else {
+						value = !value;
+					}
 				}
 
 				set(expressionValues, operand.value, value);

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -126,8 +126,7 @@ export class IfStep extends BaseStep {
 		try {
 			const tokens = tokenizeExpression(exp);
 			const ast = parseExpression(tokens);
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			const expression = printExpression(ast);
+			const _expression = printExpression(ast);
 			const result = evaluateExpression(ast, expressionValues);
 
 			this.processingLogs.push('Evaluated to: ' + result);

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -77,6 +77,8 @@ import { BaseStep } from './base-step';
 	output: ['Scalar', 'Series', 'Event', 'Number'],
 })
 export class IfStep extends BaseStep {
+	static acceptsMissingInputs = true;
+
 	originalExpr;
 
 	async process(): Promise<Signal> {

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -30,9 +30,32 @@ import { BaseStep } from './base-step';
 		
 		Parentheses can be used to influence the order of evaluation.
 		
-		Only numbers and single-element arrays can be part of operands in the
-		expression. In addition, a single input can be used to check for existence 
-		of values.
+		You are able to use "functions" in the expression to validate if a 
+		signal is empty or exists. The following functions are supported:
+
+		* ''empty(signalName)'' - Returns true if the signal is empty, 
+		i.e. the signal does not exist or the value is falsy 
+		(false, null, NaN, empty string).
+		* ''exists(signalName)'' - Returns true if the signal exists, 
+		i.e. the signal is _defined_. This function does not validate 
+		the _value_ of the signal but _only_ if the signal is defined 
+		or not. The signal value could be falsy, but as long as the 
+		signal is defined, this function will return true.
+		
+		***Note:** Due to the way YAML is parsed, you must wrap expressions
+		beginning with an exclamation mark in quotes, e.g. ''"!empty(mySignal)"''.*
+
+		***Note:** In order to be able to evaluate missing signals, this 
+		step does not validate the inputs to the expression. To validate 
+		a signal's existence, use the ''exists'' function.*
+
+		***Note:** The validation of the inputs to the ''then'' and ''else'' 
+		options are deferred until they are needed. This means that if the 
+		expression evaluates to true, but the ''then'' option is missing, 
+		the step will not fail until the ''then'' option is needed. This is 
+		done to allow for the use of references to signals that may only be 
+		able to be resolved in certain circumstances, e.g. when the 
+		expression evaluates to true.*
 	`,
 	examples: markdownFmt`
 		''' yaml
@@ -56,8 +79,34 @@ import { BaseStep } from './base-step';
 		the result is ''myDefault''.
 
 		''' yaml
-		- if: mySignal
+		- if: "!empty(mySignal)"
 		  then: mySignal
+		  else: myDefault
+		'''
+
+		The following example shows how you can check for the existence of of a
+		signal. If ''mySignal'' exists, the resulting signal would be ''mySignal'', 
+		otherwise the result is ''myDefault''.
+
+		''' yaml
+		- if: exists(mySignal)
+		  then: mySignal
+		  else: myDefault
+		'''
+
+		The following example shows how you can compare values from measurement fields.
+
+		''' yaml
+		- if: $field(My Field, measurement, numeric) > $field(My Other Field, measurement, numeric)
+		  then: mySignal
+		  else: myDefault
+		'''
+
+		The following example shows how to return a field value if it is not empty, otherwise return a default value.
+
+		''' yaml
+		- if: "!empty($field(My Field, measurement, numeric))"
+		  then: $field(My Field, measurement, numeric)
 		  else: myDefault
 		'''
 	`,

--- a/src/lib/processing/logic.ts
+++ b/src/lib/processing/logic.ts
@@ -135,7 +135,31 @@ export class IfStep extends BaseStep {
 
 			this.processingLogs.push('Evaluated to: ' + result);
 
-			return result ? thenInput[0] : elseInput[0];
+			// Handle truthy evaluation.
+			if (result) {
+				if (thenInput[0] === undefined) {
+					throw new Error('Unexpected undefined value for \'then\' option.');
+				}
+
+				// If the input is a string, it is a reference to a signal that could not be found.
+				if (thenInput[0].type === SignalType.String) {
+					throw new Error(`Could not resolve signal '${ thenInput[0].getStringValue() }' for 'then' option.`);
+				}
+
+				return thenInput[0].clone();
+			}
+
+			// Handle falsy evaluation.
+			if (elseInput[0] === undefined) {
+				throw new Error('Unexpected undefined value for \'else\' option.');
+			}
+
+			// If the input is a string, it is a reference to a signal that could not be found.
+			if (elseInput[0].type === SignalType.String) {
+				throw new Error(`Could not resolve signal '${ elseInput[0].getStringValue() }' for 'else' option.`);
+			}
+
+			return elseInput[0].clone();
 		}
 		catch (err) {
 			throw new ProcessingError('Evaluating expression failed: ' + err.message);

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -862,3 +862,70 @@ test('parseExpressionOperands - variable inputs - with options - with functions'
 		]
 	});
 });
+
+test('parseExpressionOperands - $prev inputs', (t) => {
+	t.deepEqual(parseExpressionOperands('$prev'), {
+		expression: '$prev',
+		operands: [
+			{ value: '$prev', originalValue: '$prev', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('$prev(2)'), {
+		expression: '$prev_2',
+		operands: [
+			{ value: '$prev_2', originalValue: '$prev(2)', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('$prev( 2 )'), {
+		expression: 'operand_0_$prev_2',
+		operands: [
+			{ value: 'operand_0_$prev_2', originalValue: '$prev( 2 )', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - $prev inputs - with functions', (t) => {
+	t.deepEqual(parseExpressionOperands('empty($prev)'), {
+		expression: '$prev',
+		operands: [
+			{ value: '$prev', originalValue: '$prev', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('empty($prev(2))'), {
+		expression: '$prev_2',
+		operands: [
+			{ value: '$prev_2', originalValue: '$prev(2)', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('empty($prev( 2 ))'), {
+		expression: 'operand_0_$prev_2',
+		operands: [
+			{ value: 'operand_0_$prev_2', originalValue: '$prev( 2 )', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists($prev)'), {
+		expression: '$prev',
+		operands: [
+			{ value: '$prev', originalValue: '$prev', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists($prev(2))'), {
+		expression: '$prev_2',
+		operands: [
+			{ value: '$prev_2', originalValue: '$prev(2)', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists($prev( 2 ))'), {
+		expression: 'operand_0_$prev_2',
+		operands: [
+			{ value: 'operand_0_$prev_2', originalValue: '$prev( 2 )', ...defaultResult, exists: true },
+		]
+	});
+});

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -737,6 +737,14 @@ test('parseExpressionOperands - functions - exists & empty mixed', (t) => {
 			{ value: 'bar', originalValue: 'bar', ...defaultResult },
 		]
 	});
+	
+	t.deepEqual(parseExpressionOperands('(exists(hello) && !empty(world))'), {
+		expression: '(hello && !world)',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
+		]
+	});
 });
 
 test('parseExpressionOperands - arrow output', (t) => {
@@ -751,3 +759,106 @@ test('parseExpressionOperands - arrow output', (t) => {
 	});
 });
 
+test('parseExpressionOperands - variable inputs', (t) => {
+	t.deepEqual(parseExpressionOperands('$field(Field Name)'), {
+		expression: 'operand_0_$field_FieldName',
+		operands: [
+			{ value: 'operand_0_$field_FieldName', originalValue: '$field(Field Name)', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!$field(Field Name)'), {
+		expression: '!operand_0_$field_FieldName',
+		operands: [
+			{ value: 'operand_0_$field_FieldName', originalValue: '$field(Field Name)', ...defaultResult, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists(hello) && $field(Field Name)'), {
+		expression: 'hello && operand_1_$field_FieldName',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName', originalValue: '$field(Field Name)', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists(hello) && !$field(Field Name)'), {
+		expression: 'hello && !operand_1_$field_FieldName',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName', originalValue: '$field(Field Name)', ...defaultResult, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('(exists(hello) && $field(Field Name))'), {
+		expression: '(hello && operand_1_$field_FieldName)',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName', originalValue: '$field(Field Name)', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - variable inputs - with options', (t) => {
+	t.deepEqual(parseExpressionOperands('$field(Field Name, My Measurement, numeric)'), {
+		expression: 'operand_0_$field_FieldName_MyMeasurement_numeric',
+		operands: [
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!$field(Field Name, My Measurement, numeric)'), {
+		expression: '!operand_0_$field_FieldName_MyMeasurement_numeric',
+		operands: [
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists(hello) && $field(Field Name, My Measurement, numeric)'), {
+		expression: 'hello && operand_1_$field_FieldName_MyMeasurement_numeric',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists(hello) && !$field(Field Name, My Measurement, numeric)'), {
+		expression: 'hello && !operand_1_$field_FieldName_MyMeasurement_numeric',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('(exists(hello) && $field(Field Name, My Measurement, numeric))'), {
+		expression: '(hello && operand_1_$field_FieldName_MyMeasurement_numeric)',
+		operands: [
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - variable inputs - with options - with functions', (t) => {
+	t.deepEqual(parseExpressionOperands('empty($field(Field Name, My Measurement, numeric))'), {
+		expression: 'operand_0_$field_FieldName_MyMeasurement_numeric',
+		operands: [
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists($field(Field Name, My Measurement, numeric))'), {
+		expression: 'operand_0_$field_FieldName_MyMeasurement_numeric',
+		operands: [
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('(exists($field(Field Name, My Measurement, numeric)) && !empty($field(Field Name, My Measurement, numeric)))'), {
+		expression: '(operand_0_$field_FieldName_MyMeasurement_numeric && !operand_1_$field_FieldName_MyMeasurement_numeric)',
+		operands: [
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, empty: true, isInverted: true },
+		]
+	});
+});

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -929,3 +929,12 @@ test('parseExpressionOperands - $prev inputs - with functions', (t) => {
 		]
 	});
 });
+
+test.only('parseExpressionOperands - @ syntax', (t) => {
+	t.deepEqual(parseExpressionOperands('hello@event'), {
+		expression: 'hello@event',
+		operands: [
+			{ value: 'hello@event', originalValue: 'hello@event', ...defaultResult },
+		]
+	});
+});

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -738,3 +738,16 @@ test('parseExpressionOperands - functions - exists & empty mixed', (t) => {
 		]
 	});
 });
+
+test('parseExpressionOperands - arrow output', (t) => {
+	t.deepEqual(parseExpressionOperands('hello => world'), {
+		expression: 'hello => world',
+		operands: []
+	});
+
+	t.deepEqual(parseExpressionOperands('hello > foo => world'), {
+		expression: 'hello > foo => world',
+		operands: []
+	});
+});
+

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -12,43 +12,43 @@ test('parseExpressionOperands - simple numeric', (t) => {
 	t.deepEqual(parseExpressionOperands('1 > 2'), {
 		expression: '1 > 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 < 2'), {
 		expression: '1 < 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 == 2'), {
 		expression: '1 == 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 != 2'), {
 		expression: '1 != 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 && 2'), {
 		expression: '1 && 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 || 2'), {
 		expression: '1 || 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 });
@@ -57,43 +57,69 @@ test('parseExpressionOperands - simple variables', (t) => {
 	t.deepEqual(parseExpressionOperands('hello > world'), {
 		expression: 'hello > world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello < world'), {
 		expression: 'hello < world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello == world'), {
 		expression: 'hello == world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello != world'), {
 		expression: 'hello != world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello && world'), {
 		expression: 'hello && world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello || world'), {
 		expression: 'hello || world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - simple variables with whitespace', (t) => {
+	t.deepEqual(parseExpressionOperands('My Simple Signal > My Other Signal'), {
+		expression: 'operand_0_MySimpleSignal > operand_1_MyOtherSignal',
+		operands: [
+			{ value: 'operand_0_MySimpleSignal', originalValue: 'My Simple Signal', ...defaultResult }, 
+			{ value: 'operand_1_MyOtherSignal', originalValue: 'My Other Signal', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('My Simple Signal > My Simple Signal'), {
+		expression: 'operand_0_MySimpleSignal > operand_1_MySimpleSignal',
+		operands: [
+			{ value: 'operand_0_MySimpleSignal', originalValue: 'My Simple Signal', ...defaultResult }, 
+			{ value: 'operand_1_MySimpleSignal', originalValue: 'My Simple Signal', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('My Simple Signal.x > My Simple Signal.y'), {
+		expression: 'operand_0_MySimpleSignal.x > operand_1_MySimpleSignal.y',
+		operands: [
+			{ value: 'operand_0_MySimpleSignal.x', originalValue: 'My Simple Signal.x', ...defaultResult }, 
+			{ value: 'operand_1_MySimpleSignal.y', originalValue: 'My Simple Signal.y', ...defaultResult },
 		]
 	});
 });
@@ -102,86 +128,86 @@ test('parseExpressionOperands - simple mixed', (t) => {
 	t.deepEqual(parseExpressionOperands('hello > 1'), {
 		expression: 'hello > 1',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello < 1'), {
 		expression: 'hello < 1',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello == 1'), {
 		expression: 'hello == 1',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello != 1'), {
 		expression: 'hello != 1',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello && 1'), {
 		expression: 'hello && 1',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello || 1'), {
 		expression: 'hello || 1',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('1 > hello'), {
 		expression: '1 > hello',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 < hello'), {
 		expression: '1 < hello',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 == hello'), {
 		expression: '1 == hello',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 != hello'), {
 		expression: '1 != hello',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 && hello'), {
 		expression: '1 && hello',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 || hello'), {
 		expression: '1 || hello',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
 		]
 	});
 });
@@ -190,30 +216,30 @@ test('parseExpressionOperands - chained numeric', (t) => {
 	t.deepEqual(parseExpressionOperands('1 > 2 && 3 < 4'), {
 		expression: '1 > 2 && 3 < 4',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 3, ...defaultResult }, 
-			{ value: 4, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 3, originalValue: 3, ...defaultResult }, 
+			{ value: 4, originalValue: 4, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 > 2 || 3 < 4'), {
 		expression: '1 > 2 || 3 < 4',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 3, ...defaultResult }, 
-			{ value: 4, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 3, originalValue: 3, ...defaultResult }, 
+			{ value: 4, originalValue: 4, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 > 2 && 3 < 4 || 5 == 6'), {
 		expression: '1 > 2 && 3 < 4 || 5 == 6',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 3, ...defaultResult }, 
-			{ value: 4, ...defaultResult }, 
-			{ value: 5, ...defaultResult }, 
-			{ value: 6, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 3, originalValue: 3, ...defaultResult }, 
+			{ value: 4, originalValue: 4, ...defaultResult }, 
+			{ value: 5, originalValue: 5, ...defaultResult }, 
+			{ value: 6, originalValue: 6, ...defaultResult },
 		]
 	});
 });
@@ -222,30 +248,30 @@ test('parseExpressionOperands - chained variables', (t) => {
 	t.deepEqual(parseExpressionOperands('hello > world && foo < bar'), {
 		expression: 'hello > world && foo < bar',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 'foo', ...defaultResult }, 
-			{ value: 'bar', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 'foo', originalValue: 'foo', ...defaultResult }, 
+			{ value: 'bar', originalValue: 'bar', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello > world || foo < bar'), {
 		expression: 'hello > world || foo < bar',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 'foo', ...defaultResult }, 
-			{ value: 'bar', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 'foo', originalValue: 'foo', ...defaultResult }, 
+			{ value: 'bar', originalValue: 'bar', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello > world && foo < bar || baz == qux'), {
 		expression: 'hello > world && foo < bar || baz == qux',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 'foo', ...defaultResult }, 
-			{ value: 'bar', ...defaultResult }, 
-			{ value: 'baz', ...defaultResult }, 
-			{ value: 'qux', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 'foo', originalValue: 'foo', ...defaultResult }, 
+			{ value: 'bar', originalValue: 'bar', ...defaultResult }, 
+			{ value: 'baz', originalValue: 'baz', ...defaultResult }, 
+			{ value: 'qux', originalValue: 'qux', ...defaultResult },
 		]
 	});
 });
@@ -254,60 +280,60 @@ test('parseExpressionOperands - chained mixed', (t) => {
 	t.deepEqual(parseExpressionOperands('hello > 1 && 2 < world'), {
 		expression: 'hello > 1 && 2 < world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello > 1 || 2 < world'), {
 		expression: 'hello > 1 || 2 < world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello > 1 && 2 < world || 3 == foo'), {
 		expression: 'hello > 1 && 2 < world || 3 == foo',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 1, ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 3, ...defaultResult }, 
-			{ value: 'foo', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 3, originalValue: 3, ...defaultResult }, 
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('1 > hello && world < 2'), {
 		expression: '1 > hello && world < 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 > hello || world < 2'), {
 		expression: '1 > hello || world < 2',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 2, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('1 > hello && world < 2 || foo == 3'), {
 		expression: '1 > hello && world < 2 || foo == 3',
 		operands: [
-			{ value: 1, ...defaultResult }, 
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult }, 
-			{ value: 2, ...defaultResult }, 
-			{ value: 'foo', ...defaultResult }, 
-			{ value: 3, ...defaultResult },
+			{ value: 1, originalValue: 1, ...defaultResult }, 
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult }, 
+			{ value: 2, originalValue: 2, ...defaultResult }, 
+			{ value: 'foo', originalValue: 'foo', ...defaultResult }, 
+			{ value: 3, originalValue: 3, ...defaultResult },
 		]
 	});
 });
@@ -316,64 +342,64 @@ test('parseExpressionOperands - whitespace variations', (t) => {
 	t.deepEqual(parseExpressionOperands('hello>world'), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello >world'), {
 		expression: 'hello >world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello> world'), {
 		expression: 'hello> world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello&&world'), {
 		expression: 'hello&&world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello &&world'), {
 		expression: 'hello &&world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello&& world'), {
 		expression: 'hello&& world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello||world'), {
 		expression: 'hello||world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello ||world'), {
 		expression: 'hello ||world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello|| world'), {
 		expression: 'hello|| world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
@@ -381,54 +407,54 @@ test('parseExpressionOperands - whitespace variations', (t) => {
 	t.deepEqual(parseExpressionOperands(' hello>world '), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands(' hello>world'), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('hello>world '), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('\thello>world    '), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('\thello>world'), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	
 	t.deepEqual(parseExpressionOperands('hello>world\t'), {
 		expression: 'hello>world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 	
 	t.deepEqual(parseExpressionOperands('     hello      >         world       '), {
 		expression: 'hello > world',
 		operands: [
-			{ value: 'hello', ...defaultResult }, 
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 });
@@ -437,29 +463,29 @@ test('parseExpressionOperands - negations', (t) => {
 	t.deepEqual(parseExpressionOperands('!hello'), {
 		expression: '!hello',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('!hello && !world'), {
 		expression: '!hello && !world',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true }, 
-			{ value: 'world', ...defaultResult, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult, isInverted: true },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('!hello || !world'), {
 		expression: '!hello || !world',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true }, 
-			{ value: 'world', ...defaultResult, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult, isInverted: true },
 		]
 	});
 	t.deepEqual(parseExpressionOperands('!hello && !world || foo'), {
 		expression: '!hello && !world || foo',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true }, 
-			{ value: 'world', ...defaultResult, isInverted: true }, 
-			{ value: 'foo', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true }, 
+			{ value: 'world', originalValue: 'world', ...defaultResult, isInverted: true }, 
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
 		]
 	});
 });
@@ -468,19 +494,19 @@ test('parseExpressionOperands - parenthesis', (t) => {
 	t.deepEqual(parseExpressionOperands('(hello > world) && !foo'), {
 		expression: '(hello > world) && !foo',
 		operands: [
-			{ value: 'hello', ...defaultResult },
-			{ value: 'world', ...defaultResult },
-			{ value: 'foo', ...defaultResult, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult, isInverted: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('(hello > world) && !(foo || bar)'), {
 		expression: '(hello > world) && !(foo || bar)',
 		operands: [
-			{ value: 'hello', ...defaultResult },
-			{ value: 'world', ...defaultResult },
-			{ value: 'foo', ...defaultResult },
-			{ value: 'bar', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
+			{ value: 'bar', originalValue: 'bar', ...defaultResult },
 		]
 	});
 });
@@ -489,72 +515,72 @@ test('parseExpressionOperands - functions - empty', (t) => {
 	t.deepEqual(parseExpressionOperands('empty(hello)'), {
 		expression: 'hello',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('empty(hello) && world'), {
 		expression: 'hello && world',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('(empty(hello) && world)'), {
 		expression: '(hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(empty(hello) && world)'), {
 		expression: '!(hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!((empty(hello)) && world)'), {
 		expression: '!((hello) && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!empty(hello) && world)'), {
 		expression: '!(!hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!empty(hello) && empty(world))'), {
 		expression: '!(!hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!hello && empty(world))'), {
 		expression: '!(!hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!hello && (!empty(world) || foo))'), {
 		expression: '!(!hello && (!world || foo))',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'foo', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
 		]
 	});
 });
@@ -563,72 +589,72 @@ test('parseExpressionOperands - functions - exists', (t) => {
 	t.deepEqual(parseExpressionOperands('exists(hello)'), {
 		expression: 'hello',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('exists(hello) && world'), {
 		expression: 'hello && world',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('(exists(hello) && world)'), {
 		expression: '(hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(exists(hello) && world)'), {
 		expression: '!(hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!((exists(hello)) && world)'), {
 		expression: '!((hello) && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!exists(hello) && world)'), {
 		expression: '!(!hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!exists(hello) && exists(world))'), {
 		expression: '!(!hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult, exists: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, exists: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!hello && exists(world))'), {
 		expression: '!(!hello && world)',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true },
-			{ value: 'world', ...defaultResult, exists: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, exists: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(!hello && (!exists(world) || foo))'), {
 		expression: '!(!hello && (!world || foo))',
 		operands: [
-			{ value: 'hello', ...defaultResult, isInverted: true },
-			{ value: 'world', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'foo', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
 		]
 	});
 });
@@ -637,78 +663,78 @@ test('parseExpressionOperands - functions - exists & empty mixed', (t) => {
 	t.deepEqual(parseExpressionOperands('exists(hello) && empty(world)'), {
 		expression: 'hello && world',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult, empty: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('empty(hello) && exists(world)'), {
 		expression: 'hello && world',
 		operands: [
-			{ value: 'hello', ...defaultResult, empty: true },
-			{ value: 'world', ...defaultResult, exists: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, exists: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('exists(hello) && !empty(world)'), {
 		expression: 'hello && !world',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!exists(hello) && empty(world)'), {
 		expression: '!hello && world',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world)'), {
 		expression: '!hello && !world',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world) && foo'), {
 		expression: '!hello && !world && foo',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'foo', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world) && !foo'), {
 		expression: '!hello && !world && !foo',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'foo', ...defaultResult, isInverted: true },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult, isInverted: true },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world) && !(foo || bar)'), {
 		expression: '!hello && !world && !(foo || bar)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'foo', ...defaultResult },
-			{ value: 'bar', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
+			{ value: 'bar', originalValue: 'bar', ...defaultResult },
 		]
 	});
 
 	t.deepEqual(parseExpressionOperands('!(exists(hello) && !empty(world)) && !(foo && bar)'), {
 		expression: '!(hello && !world) && !(foo && bar)',
 		operands: [
-			{ value: 'hello', ...defaultResult, exists: true },
-			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
-			{ value: 'foo', ...defaultResult },
-			{ value: 'bar', ...defaultResult },
+			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', originalValue: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', originalValue: 'foo', ...defaultResult },
+			{ value: 'bar', originalValue: 'bar', ...defaultResult },
 		]
 	});
 });

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -1,0 +1,714 @@
+import test from 'ava';
+
+import { parseExpressionOperands } from './expression';
+
+const defaultResult = {
+	isInverted: false, 
+	empty: false, 
+	exists: false,
+};
+
+test('parseExpressionOperands - simple numeric', (t) => {
+	t.deepEqual(parseExpressionOperands('1 > 2'), {
+		expression: '1 > 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 < 2'), {
+		expression: '1 < 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 == 2'), {
+		expression: '1 == 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 != 2'), {
+		expression: '1 != 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 && 2'), {
+		expression: '1 && 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 || 2'), {
+		expression: '1 || 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - simple variables', (t) => {
+	t.deepEqual(parseExpressionOperands('hello > world'), {
+		expression: 'hello > world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello < world'), {
+		expression: 'hello < world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello == world'), {
+		expression: 'hello == world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello != world'), {
+		expression: 'hello != world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello && world'), {
+		expression: 'hello && world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello || world'), {
+		expression: 'hello || world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - simple mixed', (t) => {
+	t.deepEqual(parseExpressionOperands('hello > 1'), {
+		expression: 'hello > 1',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello < 1'), {
+		expression: 'hello < 1',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello == 1'), {
+		expression: 'hello == 1',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello != 1'), {
+		expression: 'hello != 1',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello && 1'), {
+		expression: 'hello && 1',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello || 1'), {
+		expression: 'hello || 1',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('1 > hello'), {
+		expression: '1 > hello',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 < hello'), {
+		expression: '1 < hello',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 == hello'), {
+		expression: '1 == hello',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 != hello'), {
+		expression: '1 != hello',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 && hello'), {
+		expression: '1 && hello',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 || hello'), {
+		expression: '1 || hello',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - chained numeric', (t) => {
+	t.deepEqual(parseExpressionOperands('1 > 2 && 3 < 4'), {
+		expression: '1 > 2 && 3 < 4',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 3, ...defaultResult }, 
+			{ value: 4, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 > 2 || 3 < 4'), {
+		expression: '1 > 2 || 3 < 4',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 3, ...defaultResult }, 
+			{ value: 4, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 > 2 && 3 < 4 || 5 == 6'), {
+		expression: '1 > 2 && 3 < 4 || 5 == 6',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 3, ...defaultResult }, 
+			{ value: 4, ...defaultResult }, 
+			{ value: 5, ...defaultResult }, 
+			{ value: 6, ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - chained variables', (t) => {
+	t.deepEqual(parseExpressionOperands('hello > world && foo < bar'), {
+		expression: 'hello > world && foo < bar',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 'foo', ...defaultResult }, 
+			{ value: 'bar', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello > world || foo < bar'), {
+		expression: 'hello > world || foo < bar',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 'foo', ...defaultResult }, 
+			{ value: 'bar', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello > world && foo < bar || baz == qux'), {
+		expression: 'hello > world && foo < bar || baz == qux',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 'foo', ...defaultResult }, 
+			{ value: 'bar', ...defaultResult }, 
+			{ value: 'baz', ...defaultResult }, 
+			{ value: 'qux', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - chained mixed', (t) => {
+	t.deepEqual(parseExpressionOperands('hello > 1 && 2 < world'), {
+		expression: 'hello > 1 && 2 < world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello > 1 || 2 < world'), {
+		expression: 'hello > 1 || 2 < world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello > 1 && 2 < world || 3 == foo'), {
+		expression: 'hello > 1 && 2 < world || 3 == foo',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 1, ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 3, ...defaultResult }, 
+			{ value: 'foo', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('1 > hello && world < 2'), {
+		expression: '1 > hello && world < 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 > hello || world < 2'), {
+		expression: '1 > hello || world < 2',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 2, ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('1 > hello && world < 2 || foo == 3'), {
+		expression: '1 > hello && world < 2 || foo == 3',
+		operands: [
+			{ value: 1, ...defaultResult }, 
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult }, 
+			{ value: 2, ...defaultResult }, 
+			{ value: 'foo', ...defaultResult }, 
+			{ value: 3, ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - whitespace variations', (t) => {
+	t.deepEqual(parseExpressionOperands('hello>world'), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello >world'), {
+		expression: 'hello >world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello> world'), {
+		expression: 'hello> world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello&&world'), {
+		expression: 'hello&&world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello &&world'), {
+		expression: 'hello &&world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello&& world'), {
+		expression: 'hello&& world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello||world'), {
+		expression: 'hello||world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello ||world'), {
+		expression: 'hello ||world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello|| world'), {
+		expression: 'hello|| world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+
+	t.deepEqual(parseExpressionOperands(' hello>world '), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands(' hello>world'), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('hello>world '), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('\thello>world    '), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('\thello>world'), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	
+	t.deepEqual(parseExpressionOperands('hello>world\t'), {
+		expression: 'hello>world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+	
+	t.deepEqual(parseExpressionOperands('     hello      >         world       '), {
+		expression: 'hello > world',
+		operands: [
+			{ value: 'hello', ...defaultResult }, 
+			{ value: 'world', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - negations', (t) => {
+	t.deepEqual(parseExpressionOperands('!hello'), {
+		expression: '!hello',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('!hello && !world'), {
+		expression: '!hello && !world',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true }, 
+			{ value: 'world', ...defaultResult, isInverted: true },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('!hello || !world'), {
+		expression: '!hello || !world',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true }, 
+			{ value: 'world', ...defaultResult, isInverted: true },
+		]
+	});
+	t.deepEqual(parseExpressionOperands('!hello && !world || foo'), {
+		expression: '!hello && !world || foo',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true }, 
+			{ value: 'world', ...defaultResult, isInverted: true }, 
+			{ value: 'foo', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - parenthesis', (t) => {
+	t.deepEqual(parseExpressionOperands('(hello > world) && !foo'), {
+		expression: '(hello > world) && !foo',
+		operands: [
+			{ value: 'hello', ...defaultResult },
+			{ value: 'world', ...defaultResult },
+			{ value: 'foo', ...defaultResult, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('(hello > world) && !(foo || bar)'), {
+		expression: '(hello > world) && !(foo || bar)',
+		operands: [
+			{ value: 'hello', ...defaultResult },
+			{ value: 'world', ...defaultResult },
+			{ value: 'foo', ...defaultResult },
+			{ value: 'bar', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - functions - empty', (t) => {
+	t.deepEqual(parseExpressionOperands('empty(hello)'), {
+		expression: 'hello',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('empty(hello) && world'), {
+		expression: 'hello && world',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('(empty(hello) && world)'), {
+		expression: '(hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(empty(hello) && world)'), {
+		expression: '!(hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!((empty(hello)) && world)'), {
+		expression: '!((hello) && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!empty(hello) && world)'), {
+		expression: '!(!hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!empty(hello) && empty(world))'), {
+		expression: '!(!hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!hello && empty(world))'), {
+		expression: '!(!hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!hello && (!empty(world) || foo))'), {
+		expression: '!(!hello && (!world || foo))',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - functions - exists', (t) => {
+	t.deepEqual(parseExpressionOperands('exists(hello)'), {
+		expression: 'hello',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists(hello) && world'), {
+		expression: 'hello && world',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('(exists(hello) && world)'), {
+		expression: '(hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(exists(hello) && world)'), {
+		expression: '!(hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!((exists(hello)) && world)'), {
+		expression: '!((hello) && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!exists(hello) && world)'), {
+		expression: '!(!hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!exists(hello) && exists(world))'), {
+		expression: '!(!hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!hello && exists(world))'), {
+		expression: '!(!hello && world)',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(!hello && (!exists(world) || foo))'), {
+		expression: '!(!hello && (!world || foo))',
+		operands: [
+			{ value: 'hello', ...defaultResult, isInverted: true },
+			{ value: 'world', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'foo', ...defaultResult },
+		]
+	});
+});
+
+test('parseExpressionOperands - functions - exists & empty mixed', (t) => {
+	t.deepEqual(parseExpressionOperands('exists(hello) && empty(world)'), {
+		expression: 'hello && world',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('empty(hello) && exists(world)'), {
+		expression: 'hello && world',
+		operands: [
+			{ value: 'hello', ...defaultResult, empty: true },
+			{ value: 'world', ...defaultResult, exists: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('exists(hello) && !empty(world)'), {
+		expression: 'hello && !world',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!exists(hello) && empty(world)'), {
+		expression: '!hello && world',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world)'), {
+		expression: '!hello && !world',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world) && foo'), {
+		expression: '!hello && !world && foo',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world) && !foo'), {
+		expression: '!hello && !world && !foo',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', ...defaultResult, isInverted: true },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!exists(hello) && !empty(world) && !(foo || bar)'), {
+		expression: '!hello && !world && !(foo || bar)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true, isInverted: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', ...defaultResult },
+			{ value: 'bar', ...defaultResult },
+		]
+	});
+
+	t.deepEqual(parseExpressionOperands('!(exists(hello) && !empty(world)) && !(foo && bar)'), {
+		expression: '!(hello && !world) && !(foo && bar)',
+		operands: [
+			{ value: 'hello', ...defaultResult, exists: true },
+			{ value: 'world', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'foo', ...defaultResult },
+			{ value: 'bar', ...defaultResult },
+		]
+	});
+});

--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -930,7 +930,7 @@ test('parseExpressionOperands - $prev inputs - with functions', (t) => {
 	});
 });
 
-test.only('parseExpressionOperands - @ syntax', (t) => {
+test('parseExpressionOperands - @ syntax', (t) => {
 	t.deepEqual(parseExpressionOperands('hello@event'), {
 		expression: 'hello@event',
 		operands: [

--- a/src/lib/utils/expression.ts
+++ b/src/lib/utils/expression.ts
@@ -1,3 +1,5 @@
+import * as base64 from 'base-64';
+
 import { NumberUtil } from './number';
 
 export interface IExpressionOperand {
@@ -82,7 +84,7 @@ export const parseExpressionOperands = (exp: string): { operands: IExpressionOpe
 				}
 
 				const formattedString = `${ exclamationMarks }${ functionName }(${ cleanedSignal })`;
-				return '$$B64$$' + btoa(formattedString);
+				return '$$B64$$' + base64.encode(formattedString);
 			}
 
 			return v;
@@ -106,7 +108,7 @@ export const parseExpressionOperands = (exp: string): { operands: IExpressionOpe
 
 			// Decode any encoded function calls.
 			if (v.startsWith('$$B64$$')) {
-				v = atob(v.substring(7));
+				v = base64.decode(v.substring(7));
 			}
 
 			v = v.trim();

--- a/src/lib/utils/expression.ts
+++ b/src/lib/utils/expression.ts
@@ -19,6 +19,14 @@ export const parseExpressionOperands = (exp: string): { operands: IExpressionOpe
 	exp = exp.replace(/\s+/g, ' ');
 	exp = exp.trim();
 
+	if (!exp) return { operands: [], expression: exp };
+
+	if (/=>/.test(exp)) {
+		// The expression contains an output.
+		// This cannot be parsed as an expression.
+		return { operands: [], expression: exp };
+	}
+
 	// Define the logical operators that we want to match.
 	const logicalOperators = [
 		'<=', 

--- a/src/lib/utils/expression.ts
+++ b/src/lib/utils/expression.ts
@@ -1,28 +1,123 @@
 import { NumberUtil } from './number';
 
+export interface IExpressionOperand {
+	value: string | number;
+	isInverted: boolean;
+	exists: boolean;
+	empty: boolean;
+}
+
 /**
  * Parses a logical expression and returns a list of operands. If the expression
  * does not contain any operators it returns an empty array.
  * @param exp The expression to parse.
  * @returns 
  */
-export const parseExpressionOperands = (exp: string) => {
-	const logicalOperators = ['!', '<', '>', '<=', '>=', '==', '!=', '&&', '\\|\\|'];
-	const regexOperators = [];
+export const parseExpressionOperands = (exp: string): { operands: IExpressionOperand[], expression: string } => {
+	// Remove any excess whitespace from the expression.
+	exp = exp.replace(/\s+/g, ' ');
+	exp = exp.trim();
 
+	// Define the logical operators that we want to match.
+	const logicalOperators = [
+		'<=', 
+		'>=', 
+		'==', 
+		'!=', 
+		'&&', 
+		'\\|\\|',
+		// The following must be ordered after the others to avoid 
+		// matching parts of the above operators.
+		// '!', 
+		'<', 
+		'>', 
+	];
+
+	// Create a regular expression that matches any of the operators.
+	const regexOperators = [];
 	for (const op of logicalOperators) {
-		regexOperators.push('(?:[\\w\\s]' + op + '[\\w\\s])');
+		regexOperators.push('(?:[\\s]*' + op + '[\\s]*)');
 	}
+
+	const functionPattern = /^!*?[^\w!]*(!*)(empty|exists)\((.*)\)$/gi;
 
 	const regexpStr = regexOperators.join('|');
 	const regexp = new RegExp(regexpStr);
 
-	if (exp.match(regexp)) {
-		const result = exp.replace(/[()]/g, '').split(regexp).map(v => NumberUtil.isNumeric(v) ? parseFloat(v) : v);
+	const result: IExpressionOperand[] = exp
+		// Split the expression by the operators.
+		.split(regexp)
+		// Remove any empty or undefined values.
+		.filter(v => v !== undefined && v !== '')
+		// Parse any numeric values as floats.
+		// Check if the expression is inverted.
+		// Package the result in an object.
+		.map(v => v.trim())
+		// Extract any function calls (empty and exists).
+		// Encode them in a way that avoids parenthesis.
+		.map(v => {
+			functionPattern.lastIndex = 0;
+			const functionMatches = functionPattern.exec(v);
 
-		return result;
-	}
-	else {
-		return [];
-	}
+			if (functionMatches && functionMatches.length === 4) {
+				const [_, exclamationMarks, functionName, signal] = functionMatches;
+				return `${ exclamationMarks }$$${ functionName }$$${ signal }`;
+			}
+
+			return v;
+		})
+		// Remove any parentheses.
+		// Also remove any exclamation marks 
+		// that are adjacent to parentheses.
+		.map(v => v.replace(/!?[()]/g, ''))
+		.map(v => {
+			if (NumberUtil.isNumeric(v)) {
+				return {
+					value: parseFloat(v),
+					isInverted: false,
+					empty: false,
+					exists: false,
+				};
+			}
+
+			v = v.trim();
+			// Replace extraneous exclamation marks (since two 
+			// exclamation marks cancels out).
+			v = v.replace(/!!/g, '');
+
+			const isInverted = v.startsWith('!');
+
+			if (isInverted) {
+				v = v.substring(1).trim();
+			}
+
+			// Detect encoded function calls.
+			let empty = false;
+			let exists = false;
+
+			const functionMatches = v.match(/^\$\$(empty|exists)\$\$(.*)$/);
+
+			if (functionMatches && functionMatches.length === 3) {
+				v = functionMatches[2];
+				empty = functionMatches[1] === 'empty';
+				exists = functionMatches[1] === 'exists';
+			}
+
+			return {
+				value: v,
+				isInverted: isInverted,
+				exists: exists,
+				empty: empty,
+			};
+		})
+	;
+
+	// Clean up function calls from the expression.
+	const functionCleanPattern = /(!*)(empty|exists)\((.*?)\)/gi;
+	exp = exp.replace(functionCleanPattern, '$1$3');
+
+	return {
+		operands: result,
+		expression: exp,
+	};
 };

--- a/src/lib/utils/expression.ts
+++ b/src/lib/utils/expression.ts
@@ -50,7 +50,7 @@ export const parseExpressionOperands = (exp: string): { operands: IExpressionOpe
 		regexOperators.push('(?:[\\s]*' + op + '[\\s]*)');
 	}
 
-	const functionPattern = /^!*?[^\w!]*(!*)(empty|exists|\$field)\(([^)]+\))\)*$/gi;
+	const functionPattern = /^!*?[^\w!]*(!*)(empty|exists|\$field|\$prev)\(([^)]+\))\)*$/gi;
 
 	const regexpStr = regexOperators.join('|');
 	const regexp = new RegExp(regexpStr);
@@ -143,6 +143,13 @@ export const parseExpressionOperands = (exp: string): { operands: IExpressionOpe
 
 			if (fieldMatches && fieldMatches.length === 2) {
 				v = '$field_' + fieldMatches[1].split(',').join('_');
+			}
+
+			// Clean up $prev calls from the expression.
+			const prevMatches = v.match(/^\$prev\((.*)\)$/);
+
+			if (prevMatches && prevMatches.length === 2) {
+				v = '$prev_' + prevMatches[1].split(',').join('_');
 			}
 
 			// Remove any whitespace from the operands.

--- a/src/lib/utils/sequence.ts
+++ b/src/lib/utils/sequence.ts
@@ -22,7 +22,6 @@ export class SequenceUtil {
 		const indexRows = [];
 		
 		// Keep track of the current index of each column.
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const colRowIndex = maps.map(_ => 0);
 		
 		// The current frame number.

--- a/src/test-utils/mock-step.ts
+++ b/src/test-utils/mock-step.ts
@@ -43,12 +43,14 @@ export const mockStep = <S extends BaseStep>(stepClass: { new (node: IStepNode, 
 	const inputSignals = Array.isArray(inputs) ? inputs : Object.values(inputs);
 	// Get the input names or generate new ones if none was provided.
 	const inputNames = Array.isArray(inputs) ? inputs.map((_, i) => 'Input ' + (i + 1)) : Object.keys(inputs);
+
+	const stepAcceptsMissingInputs = (stepClass as unknown as typeof BaseStep).acceptsMissingInputs;
 	
 	// Find options whose value is an array of Signals, then create a Map.
 	// These are used to mock the `Inputs` object for the step class.
 	const optionSignals = Object
 		.entries(options || {})
-		.map(entry => (Array.isArray(entry[1]) && entry[1][0] instanceof Signal) ? entry : [entry[0], [new Signal(entry[1])]]) as [string, Signal[]][]
+		.map(entry => (Array.isArray(entry[1]) && entry[1][0] instanceof Signal) ? entry : [entry[0], [(!stepAcceptsMissingInputs || (entry[1] !== undefined && entry[1][0] !== undefined)) ? new Signal(entry[1]) : undefined]]) as [string, Signal[]][]
 	;
 	const optionSignalsMap = new Map(optionSignals);
 


### PR DESCRIPTION
This PR improves the expression parsing ability for the `if` step.

Summary of changes:

- Added tests for `parseExpressionOperands` function.
- Handles signal names with spaces.
- Adds support for the `exists` and `empty` functions.
- Adds support for referencing fields.
- Does not stop processing if any of the inputs are empty.
- Defers checking the `then` and `else` option inputs until they are needed.
- Allow more input data types (anything but signals with components).

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

## Updated step documentation:

---

## Steps

### `if`

**Inputs**
>
> 1. `Logical expression`
>

**Output:** `Scalar | Series | Event | Number`

**Options**
>
> #### `then`
>
> **Type:** `any`  
> **Required:** `True`  

>
> #### `else`
>
> **Type:** `any`  
> **Required:** `True`  

>

**Shared options**
>
> <details><summary>Global options</summary>
> 
> The following options are available globally on all steps.
>
> * [export](./index.md#export)
> * [output](./index.md#output)
> * [set](./index.md#set)
> * [space](./index.md#space)
>
>
></details>
>


Runs a logical expression. The return value is determined by the 
result of the expression, and the `then` and `else` options.

The following operators are supported:

<pre><  >  >=  <=  ==  !=  &&  ||  !</pre>

Parentheses can be used to influence the order of evaluation.

You are able to use "functions" in the expression to validate if a 
signal is empty or exists. The following functions are supported:

* `empty(signalName)` - Returns true if the signal is empty, 
i.e. the signal does not exist or the value is falsy 
(false, null, NaN, empty string).
* `exists(signalName)` - Returns true if the signal exists, 
i.e. the signal is _defined_. This function does not validate 
the _value_ of the signal but _only_ if the signal is defined 
or not. The signal value could be falsy, but as long as the 
signal is defined, this function will return true.

***Note:** Due to the way YAML is parsed, you must wrap expressions
beginning with an exclamation mark in quotes, e.g. `"!empty(mySignal)"`.*

***Note:** In order to be able to evaluate missing signals, this 
step does not validate the inputs to the expression. To validate 
a signal's existence, use the `exists` function.*

***Note:** The validation of the inputs to the `then` and `else` 
options are deferred until they are needed. This means that if the 
expression evaluates to true, but the `then` option is missing, 
the step will not fail until the `then` option is needed. This is 
done to allow for the use of references to signals that may only be 
able to be resolved in certain circumstances, e.g. when the 
expression evaluates to true.*

## Examples

``` yaml
- parameter: myCondition
  steps:
    - segment: RightFoot => rfoot
    - segment: LeftFoot => lfoot
    - if: 10 > 5
      then: rfoot
      else: lfoot
```

``` yaml
- if: (posY > 10 || posY < 5) && posX != 0
  then: posY
  else: posX
```

The following example shows how you can check for the existence of values in a
signal. If `mySignal` has values, the resulting signal would be `mySignal`, otherwise
the result is `myDefault`.

``` yaml
- if: "!empty(mySignal)"
  then: mySignal
  else: myDefault
```

The following example shows how you can check for the existence of of a
signal. If `mySignal` exists, the resulting signal would be `mySignal`, 
otherwise the result is `myDefault`.

``` yaml
- if: exists(mySignal)
  then: mySignal
  else: myDefault
```

The following example shows how you can compare values from measurement fields.

``` yaml
- if: $field(My Field, measurement, numeric) > $field(My Other Field, measurement, numeric)
  then: mySignal
  else: myDefault
```

The following example shows how to return a field value if it is not empty, otherwise return a default value.

``` yaml
- if: "!empty($field(My Field, measurement, numeric))"
  then: $field(My Field, measurement, numeric)
  else: myDefault
```


---

Work item: [AB#32332](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/32332)