### PR TITLE
More flexible handling of data types in concat step

### DIFF
--- a/docs/nodes/steps/data-structure.md
+++ b/docs/nodes/steps/data-structure.md
@@ -42,6 +42,11 @@ The `concatenate` step takes any number of inputs (at least 2)
 of the same (or equivalent) types and appends the values into one 
 output. This will be done on each component, if they exist.
 
+Scalar inputs will be converted to arrays. 
+
+If all the inputs are integer arrays, the output will be an integer array.
+However, if any of the inputs are floats, the output will be a float array.
+
 ## Examples
 
 The following example calculates the average "step length" 

--- a/src/lib/processing/concatenate.spec.ts
+++ b/src/lib/processing/concatenate.spec.ts
@@ -36,6 +36,42 @@ test('ConcatenateStep - 1D array x 6', async(t) => {
 	t.deepEqual(res.getValue(), f32(1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6));
 });
 
+test('ConcatenateStep - Scalar inputs', async(t) => {
+	const step = mockStep(ConcatenateStep, [
+		new Signal(1),
+		new Signal(2),
+		new Signal(3),
+		new Signal(4),
+		new Signal(5),
+		new Signal(6),
+	]);
+	const res = await step.process();
+
+	t.deepEqual(res.getValue(), f32(1, 2, 3, 4, 5, 6));
+});
+
+test('ConcatenateStep - Mixed scalar and array inputs', async(t) => {
+	const res1 = await mockStep(ConcatenateStep, [
+		s1,
+		new Signal(4),
+		new Signal(5),
+		s2,
+		new Signal(6),
+	]).process();
+
+	t.deepEqual(res1.getValue(), f32(1, 2, 3, 4, 5, 4, 5, 6, 6));
+
+	const res2 = await mockStep(ConcatenateStep, [
+		new Signal(4),
+		new Signal(5),
+		s1,
+		new Signal(6),
+		s2,
+	]).process();
+
+	t.deepEqual(res2.getValue(), f32(4, 5, 1, 2, 3, 6, 4, 5, 6));
+});
+
 test('ConcatenateStep - Multi-components (Segment)', async(t) => {
 	const step = mockStep(ConcatenateStep, [segment1, segment2]);
 	const res = await step.process();

--- a/src/lib/processing/concatenate.spec.ts
+++ b/src/lib/processing/concatenate.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { f32, mockStep } from '../../test-utils/mock-step';
+import { f32, i32, mockStep } from '../../test-utils/mock-step';
 import { Segment } from '../models/segment';
 import { QuaternionSequence } from '../models/sequence/quaternion-sequence';
 import { VectorSequence } from '../models/sequence/vector-sequence';
@@ -70,6 +70,57 @@ test('ConcatenateStep - Mixed scalar and array inputs', async(t) => {
 	]).process();
 
 	t.deepEqual(res2.getValue(), f32(4, 5, 1, 2, 3, 6, 4, 5, 6));
+});
+
+test('ConcatenateStep - Integer array inputs', async(t) => {
+	// Two integer arrays
+	const res1 = await mockStep(ConcatenateStep, [
+		new Signal(i32(1, 2, 3)),
+		new Signal(i32(4, 5, 6)),
+	]).process();
+
+	// Return integer array
+	t.deepEqual(res1.getValue(), i32(1, 2, 3, 4, 5, 6));
+
+	// One float array, one integer array
+	const res2 = await mockStep(ConcatenateStep, [
+		new Signal(f32(1, 2, 3)),
+		new Signal(i32(4, 5, 6)),
+	]).process();
+
+	// Return float array
+	t.deepEqual(res2.getValue(), f32(1, 2, 3, 4, 5, 6));
+
+	// One integer array, one float array
+	const res3 = await mockStep(ConcatenateStep, [
+		new Signal(i32(1, 2, 3)),
+		new Signal(f32(4, 5, 6)),
+	]).process();
+
+	// Return float array
+	t.deepEqual(res3.getValue(), f32(1, 2, 3, 4, 5, 6));
+
+	// One integer array, some numbers
+	const res4 = await mockStep(ConcatenateStep, [
+		new Signal(i32(1, 2, 3)),
+		new Signal(4),
+		new Signal(5),
+		new Signal(6),
+	]).process();
+
+	// Return float array
+	t.deepEqual(res4.getValue(), f32(1, 2, 3, 4, 5, 6));
+
+	// Some numbers, one integer array
+	const res5 = await mockStep(ConcatenateStep, [
+		new Signal(1),
+		new Signal(2),
+		new Signal(3),
+		new Signal(i32(4, 5, 6)),
+	]).process();
+
+	// Return float array
+	t.deepEqual(res5.getValue(), f32(1, 2, 3, 4, 5, 6));
 });
 
 test('ConcatenateStep - Multi-components (Segment)', async(t) => {

--- a/src/lib/processing/concatenate.ts
+++ b/src/lib/processing/concatenate.ts
@@ -1,4 +1,4 @@
-import { Signal } from '../models/signal';
+import { Signal, SignalType } from '../models/signal';
 import { StepCategory, StepClass } from '../step-registry';
 import { ProcessingError } from '../utils/processing-error';
 import { SeriesUtil } from '../utils/series';
@@ -55,8 +55,13 @@ export class ConcatenateStep extends BaseStep {
 			)
 		);
 
+		let targetType = this.inputs[0].type;
+		if (targetType === SignalType.Float32) {
+			targetType = SignalType.Float32Array;
+		}
+
 		// Create a new instance of the same type as the input.
-		const returnData = Signal.typeFromArray(this.inputs[0].type, concatArrays as TypedArray[]);
+		const returnData = Signal.typeFromArray(targetType, concatArrays as TypedArray[]);
 
 		return this.inputs[0].clone(returnData);
 	}

--- a/src/lib/processing/concatenate.ts
+++ b/src/lib/processing/concatenate.ts
@@ -47,10 +47,19 @@ export class ConcatenateStep extends BaseStep {
 
 		if (!arrays.every(a => a.length === arrays[0].length)) throw new ProcessingError('Expected all inputs to be of equivalent types.');
 
+		let referenceArray = arrays[0][0];
+
+		if (this.inputs[0].type === SignalType.Uint32Array) {
+			// If not all inputs are Uint32Arrays, we need to use float arrays instead.
+			if (!this.inputs.every(i => i.type === SignalType.Uint32Array)) {
+				referenceArray = new Float32Array();
+			}
+		}
+
 		const baseArray = arrays.shift();
 		const concatArrays = baseArray.map((arr, index) =>
 			SeriesUtil.createNumericArrayOfSameType(
-				arr,
+				referenceArray,
 				[...arr].concat(...arrays.map(a => [...a[index]]))
 			)
 		);

--- a/src/lib/processing/concatenate.ts
+++ b/src/lib/processing/concatenate.ts
@@ -19,7 +19,12 @@ import { BaseStep } from './base-step';
 	description: markdownFmt`
 		The ''concatenate'' step takes any number of inputs (at least 2) 
 		of the same (or equivalent) types and appends the values into one 
-		output. This will be done on each component, if they exist.`,
+		output. This will be done on each component, if they exist.
+		
+		Scalar inputs will be converted to arrays. 
+		
+		If all the inputs are integer arrays, the output will be an integer array.
+		However, if any of the inputs are floats, the output will be a float array.`,
 	examples: markdownFmt`
 		The following example calculates the average "step length" 
 		by concatenating the (already calculated) ''Right_Step_Length'' 


### PR DESCRIPTION
* Returns an array when concatenating multiple scalar numbers. 
* Better handling of combining integer and float arrays (resulting in float arrays).

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Example

``` yaml
- parameter: All My Favourite Numbers
  steps:
    - import: [2]
      output: two
    - concatenate: [1, two, [3, 4, 5], 6] # returns [1, 2, 3, 4, 5, 6]
```

Work item: [AB#32591](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/32591)