### PR TITLE
Include or exclude events from event cycles

### DIFF
--- a/docs/nodes/steps/event-utility.md
+++ b/docs/nodes/steps/event-utility.md
@@ -23,6 +23,29 @@ in various ways.
 
 **Output:** `Scalar`
 
+**Options**
+>
+> #### `exclude`
+>
+> **Type:** `Number | Number array`  
+> **Required:** `False`  
+> **Default value:** `null`  
+>
+> One or more event signals that should invalidate an event
+> sequence. If any of these events occur within a sequence,
+> the sequence is invalidated.
+>
+> #### `include`
+>
+> **Type:** `Number | Number array`  
+> **Required:** `False`  
+> **Default value:** `null`  
+>
+> One or more event signals that should be included in an
+> event sequence, otherwise it is excluded. If multiple 
+> events are supplied, all of them must be present in each
+> sequence for it to be included.
+>
 
 **Shared options**
 >
@@ -101,6 +124,27 @@ the "from", or "to" input event.
 > that were not within an "event pair" should be removed or not. 
 >
 > This will only apply if `replacement` does not have a value.
+>
+> #### `exclude`
+>
+> **Type:** `Number | Number array`  
+> **Required:** `False`  
+> **Default value:** `null`  
+>
+> One or more event signals that should invalidate an event
+> sequence. If any of these events occur within a sequence,
+> the sequence is invalidated.
+>
+> #### `include`
+>
+> **Type:** `Number | Number array`  
+> **Required:** `False`  
+> **Default value:** `null`  
+>
+> One or more event signals that should be included in an
+> event sequence, otherwise it is excluded. If multiple 
+> events are supplied, all of them must be present in each
+> sequence for it to be included.
 >
 
 **Shared options**

--- a/src/lib/processing/events/event-duration.spec.ts
+++ b/src/lib/processing/events/event-duration.spec.ts
@@ -40,8 +40,6 @@ test('EventDurationStep - exclude single', async(t) => {
 	const step = mockStep(EventDurationStep, [framesA, framesB], { exclude: [exclude] });
 	const res = await step.process();
 
-	console.log(res.getValue());
-
 	t.deepEqual(res.getValue(), f32(0.09, 0.14, 0.24));
 });
 
@@ -54,8 +52,6 @@ test('EventDurationStep - exclude multiple', async(t) => {
 	const step = mockStep(EventDurationStep, [framesA, framesB], { exclude: [excludeA, excludeB] });
 	const res = await step.process();
 
-	console.log(res.getValue());
-
 	t.deepEqual(res.getValue(), f32(0.14, 0.24));
 });
 
@@ -66,8 +62,6 @@ test('EventDurationStep - include single', async(t) => {
 	
 	const step = mockStep(EventDurationStep, [framesA, framesB], { include: [include] });
 	const res = await step.process();
-
-	console.log(res.getValue());
 
 	t.deepEqual(res.getValue(), f32(0.09, 0.14, 0.24));
 });
@@ -81,7 +75,18 @@ test('EventDurationStep - include multiple', async(t) => {
 	const step = mockStep(EventDurationStep, [framesA, framesB], { include: [includeA, includeB] });
 	const res = await step.process();
 
-	console.log(res.getValue());
-
 	t.deepEqual(res.getValue(), f32(0.14, 0.24));
+});
+
+test('EventMaskStep - include and exclude', async(t) => {
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const exclude = new Signal(i32(22, 32), 100);
+	const include = new Signal(i32(12, 24, 62), 100);
+
+	const step = mockStep(EventDurationStep, [framesA, framesB], { exclude: [exclude], include: [include] });
+
+	const res = await step.process();
+
+	t.deepEqual(res.getValue(), f32(0.09, 0.24));
 });

--- a/src/lib/processing/events/event-duration.spec.ts
+++ b/src/lib/processing/events/event-duration.spec.ts
@@ -90,3 +90,13 @@ test('EventMaskStep - include and exclude', async(t) => {
 
 	t.deepEqual(res.getValue(), f32(0.09, 0.24));
 });
+
+test('EventMaskStep - incompatible include', async(t) => {
+	await t.throwsAsync(mockStep(EventDurationStep, [e1, e2], { include: [new Signal('My string')]}).process());
+	await t.throwsAsync(mockStep(EventDurationStep, [e1, e2], { include: [s1]}).process());
+});
+
+test('EventMaskStep - incompatible exclude', async(t) => {
+	await t.throwsAsync(mockStep(EventDurationStep, [e1, e2], { exclude: [new Signal('My string')]}).process());
+	await t.throwsAsync(mockStep(EventDurationStep, [e1, e2], { exclude: [s1]}).process());
+});

--- a/src/lib/processing/events/event-duration.spec.ts
+++ b/src/lib/processing/events/event-duration.spec.ts
@@ -31,3 +31,57 @@ test('EventDurationStep', async(t) => {
 
 	t.deepEqual(res.getValue(), f32(...eventFrames1).map((f, i) => (eventFrames2[i] - f) / frameRate));
 });
+
+test('EventDurationStep - exclude single', async(t) => {
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const exclude = new Signal(i32(2, 3, 32), 100);
+
+	const step = mockStep(EventDurationStep, [framesA, framesB], { exclude: [exclude] });
+	const res = await step.process();
+
+	console.log(res.getValue());
+
+	t.deepEqual(res.getValue(), f32(0.09, 0.14, 0.24));
+});
+
+test('EventDurationStep - exclude multiple', async(t) => {
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const excludeA = new Signal(i32(2, 3, 32), 100);
+	const excludeB = new Signal(i32(7, 33), 100);
+
+	const step = mockStep(EventDurationStep, [framesA, framesB], { exclude: [excludeA, excludeB] });
+	const res = await step.process();
+
+	console.log(res.getValue());
+
+	t.deepEqual(res.getValue(), f32(0.14, 0.24));
+});
+
+test('EventDurationStep - include single', async(t) => {
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const include = new Signal(i32(12, 24, 62), 100);
+	
+	const step = mockStep(EventDurationStep, [framesA, framesB], { include: [include] });
+	const res = await step.process();
+
+	console.log(res.getValue());
+
+	t.deepEqual(res.getValue(), f32(0.09, 0.14, 0.24));
+});
+
+test('EventDurationStep - include multiple', async(t) => {
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const includeA = new Signal(i32(12, 24, 62), 100);
+	const includeB = new Signal(i32(27, 72), 100);
+	
+	const step = mockStep(EventDurationStep, [framesA, framesB], { include: [includeA, includeB] });
+	const res = await step.process();
+
+	console.log(res.getValue());
+
+	t.deepEqual(res.getValue(), f32(0.14, 0.24));
+});

--- a/src/lib/processing/events/event-mask.spec.ts
+++ b/src/lib/processing/events/event-mask.spec.ts
@@ -206,3 +206,114 @@ test('EventMaskStep - Multidimensional array - truncate', async(t) => {
 	t.deepEqual(res.cycles, cyclesTruncated);
 	t.deepEqual(res.array, [compTruncated, compTruncated, compTruncated, compTruncated, compTruncated, compTruncated, compTruncated]);
 });
+
+test('EventMaskStep - exclude single', async(t) => {
+	const signal = new Signal(new Float32Array(100).fill(50), 100);
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const exclude = new Signal(i32(2, 3, 32), 100);
+
+	const res = await mockStep(EventMaskStep, [signal, framesA, framesB], {
+		exclude: [exclude],
+	}).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.cycles, [{
+		start: 5,
+		end: 14,
+	}, {
+		start: 15,
+		end: 29,
+	}, {
+		start: 55,
+		end: 79,
+	}]);
+});
+
+test('EventMaskStep - exclude multiple', async(t) => {
+	const signal = new Signal(new Float32Array(100).fill(50), 100);
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const excludeA = new Signal(i32(2, 3, 32), 100);
+	const excludeB = new Signal(i32(7, 33), 100);
+
+	const res = await mockStep(EventMaskStep, [signal, framesA, framesB], {
+		exclude: [excludeA, excludeB],
+	}).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.cycles, [{
+		start: 15,
+		end: 29,
+	}, {
+		start: 55,
+		end: 79,
+	}]);
+});
+
+test('EventMaskStep - include single', async(t) => {
+	const signal = new Signal(new Float32Array(100).fill(50), 100);
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const include = new Signal(i32(12, 24, 62), 100);
+
+	const res = await mockStep(EventMaskStep, [signal, framesA, framesB], {
+		include: [include],
+	}).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.cycles, [{
+		start: 5,
+		end: 14,
+	}, {
+		start: 15,
+		end: 29,
+	}, {
+		start: 55,
+		end: 79,
+	}]);
+});
+
+test('EventMaskStep - include multiple', async(t) => {
+	const signal = new Signal(new Float32Array(100).fill(50), 100);
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const includeA = new Signal(i32(12, 24, 62), 100);
+	const includeB = new Signal(i32(27, 72), 100);
+
+	const res = await mockStep(EventMaskStep, [signal, framesA, framesB], {
+		include: [includeA, includeB],
+	}).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.cycles, [{
+		start: 15,
+		end: 29,
+	}, {
+		start: 55,
+		end: 79,
+	}]);
+});
+
+test('EventMaskStep - include and exclude', async(t) => {
+	const signal = new Signal(new Float32Array(100).fill(50), 100);
+	const framesA = new Signal(i32(1, 5, 15, 30, 55), 100);
+	const framesB = new Signal(i32(4, 14, 29, 54, 79), 100);
+	const exclude = new Signal(i32(22, 32), 100);
+	const include = new Signal(i32(12, 24, 62), 100);
+
+	const res = await mockStep(EventMaskStep, [signal, framesA, framesB], {
+		include: [include],
+		exclude: [exclude],
+	}).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+
+	t.deepEqual(res.cycles, [{
+		start: 5,
+		end: 14,
+	}, {
+		start: 55,
+		end: 79,
+	}]);
+});

--- a/src/lib/processing/events/event-mask.spec.ts
+++ b/src/lib/processing/events/event-mask.spec.ts
@@ -317,3 +317,13 @@ test('EventMaskStep - include and exclude', async(t) => {
 		end: 79,
 	}]);
 });
+
+test('EventMaskStep - incompatible include', async(t) => {
+	await t.throwsAsync(mockStep(EventMaskStep, [s2, e1, e2], { include: [new Signal('My string')]}).process());
+	await t.throwsAsync(mockStep(EventMaskStep, [s2, e1, e2], { include: [new Signal(vs)]}).process());
+});
+
+test('EventMaskStep - incompatible exclude', async(t) => {
+	await t.throwsAsync(mockStep(EventMaskStep, [s2, e1, e2], { exclude: [new Signal('My string')]}).process());
+	await t.throwsAsync(mockStep(EventMaskStep, [s2, e1, e2], { exclude: [new Signal(vs)]}).process());
+});

--- a/src/lib/processing/events/event-mask.ts
+++ b/src/lib/processing/events/event-mask.ts
@@ -101,6 +101,28 @@ import { BaseStep } from '../base-step';
 			
 			This will only apply if ''replacement'' does not have a value.
 		`,
+	}, {
+		name: 'exclude',
+		type: ['Number', 'Number array'],
+		required: false,
+		default: 'null',
+		description: markdownFmt`
+			One or more event signals that should invalidate an event
+			sequence. If any of these events occur within a sequence,
+			the sequence is invalidated.
+		`,
+	},
+	{
+		name: 'include',
+		type: ['Number', 'Number array'],
+		required: false,
+		default: 'null',
+		description: markdownFmt`
+			One or more event signals that should be included in an
+			event sequence, otherwise it is excluded. If multiple 
+			events are supplied, all of them must be present in each
+			sequence for it to be included.
+		`,
 	}],
 	output: ['Scalar', 'Series', 'Event', 'Number'],
 })
@@ -108,6 +130,9 @@ export class EventMaskStep extends BaseStep {
 	replacementValue: number;
 	keep: number[];
 	truncate: boolean;
+	exclude: Signal[];
+	include: Signal[];
+
 
 	init() {
 		super.init();
@@ -128,6 +153,9 @@ export class EventMaskStep extends BaseStep {
 		}
 
 		this.truncate = this.getPropertyValue<boolean>('truncate', PropertyType.Boolean, false);
+
+		this.exclude = this.getPropertySignalValue('exclude', PropertyType.Any, false);
+		this.include = this.getPropertySignalValue('include', PropertyType.Any, false);
 	}
 
 	async process(): Promise<Signal> {
@@ -152,12 +180,23 @@ export class EventMaskStep extends BaseStep {
 			throw new ProcessingError('Input 2 and 3 are expected to be events.');
 		}
 
+		if (this.exclude && this.exclude.find(s => !s.isEventLike)) {
+			throw new ProcessingError('The event duration step expects only events in the exclude option.');
+		}
+
+		if (this.include && this.include.find(s => !s.isEventLike)) {
+			throw new ProcessingError('The event duration step expects only events in the include option.');
+		}
+
 		// Expect a one-dimensional array, round all values and cast into a Uint array.
 		const fromFrames = Uint32Array.from(from.array[0].map(v => Math.round(v)));
 		const toFrames = Uint32Array.from(to.array[0].map(v => Math.round(v)));
 
+		const excludeFrames = this.exclude?.map(i => i.getEventArrayValue());
+		const includeFrames = this.include?.map(i => i.getEventArrayValue());
+
 		// Generate event frame pairs
-		const pairs = EventUtil.eventSequence(fromFrames, toFrames);
+		const pairs = EventUtil.eventSequence(fromFrames, toFrames, excludeFrames, includeFrames);
 
 		/**
 		 * If the signal input is an event, only event frames that is 

--- a/src/lib/processing/events/event-mask.ts
+++ b/src/lib/processing/events/event-mask.ts
@@ -181,11 +181,11 @@ export class EventMaskStep extends BaseStep {
 		}
 
 		if (this.exclude && this.exclude.find(s => !s.isEventLike)) {
-			throw new ProcessingError('The event duration step expects only events in the exclude option.');
+			throw new ProcessingError('The event mask step expects only events in the exclude option.');
 		}
 
 		if (this.include && this.include.find(s => !s.isEventLike)) {
-			throw new ProcessingError('The event duration step expects only events in the include option.');
+			throw new ProcessingError('The event mask step expects only events in the include option.');
 		}
 
 		// Expect a one-dimensional array, round all values and cast into a Uint array.

--- a/src/lib/utils/events.spec.ts
+++ b/src/lib/utils/events.spec.ts
@@ -21,6 +21,90 @@ test('EventUtil - eventSequence', (t) => {
 	t.deepEqual(spans2, []);
 });
 
+test('EventUtil - eventSequence - exclude single', (t) => {
+	const framesA = [1, 5, 10, 15, 20];
+	const framesB = [4, 9, 14, 19, 24];
+	const exclude = [2, 3, 16];
+
+	const spans = EventUtil.eventSequence(framesA, framesB, [exclude]);
+
+	t.deepEqual(spans, [
+		{ start: 5, end: 9 },
+		{ start: 10, end: 14 },
+		{ start: 20, end: 24 },
+	]);
+});
+
+test('EventUtil - eventSequence - exclude multiple', (t) => {
+	const framesA = [1, 5, 10, 15, 20];
+	const framesB = [4, 9, 14, 19, 24];
+	const excludeA = [2, 3, 16];
+	const excludeB = [4, 8];
+	const excludeC = [22];
+
+	const spans = EventUtil.eventSequence(framesA, framesB, [excludeA, excludeB, excludeC]);
+
+	t.deepEqual(spans, [
+		{ start: 10, end: 14 },
+	]);
+});
+
+test('EventUtil - eventSequence - include single', (t) => {
+	const framesA = [1, 5, 10, 15, 20];
+	const framesB = [4, 9, 14, 19, 24];
+	const include = [2, 3, 16];
+
+	const spans = EventUtil.eventSequence(framesA, framesB, undefined, [include]);
+
+	t.deepEqual(spans, [
+		{ start: 1, end: 4 },
+		{ start: 15, end: 19 },
+	]);
+});
+
+test('EventUtil - eventSequence - include multiple', (t) => {
+	const framesA = [1, 5, 10, 15, 20];
+	const framesB = [4, 9, 14, 19, 24];
+	const includeA = [2, 3, 16];
+	const includeB = [8, 12, 18];
+	const includeC = [13, 17, 21];
+
+	const spans = EventUtil.eventSequence(framesA, framesB, undefined, [includeA, includeB, includeC]);
+
+	t.deepEqual(spans, [
+		{ start: 15, end: 19 },
+	]);
+});
+
+test('EventUtil - eventSequence - include and exclude - single', (t) => {
+	const framesA = [1, 5, 10, 15, 20];
+	const framesB = [4, 9, 14, 19, 24];
+	const exclude = [4, 17];
+	const include = [2, 3, 8, 12, 16];
+
+	const spans = EventUtil.eventSequence(framesA, framesB, [exclude], [include]);
+
+	t.deepEqual(spans, [
+		{ start: 5, end: 9 },
+		{ start: 10, end: 14 },
+	]);
+});
+
+test('EventUtil - eventSequence - include and exclude - multiple', (t) => {
+	const framesA = [1, 5, 10, 15, 20];
+	const framesB = [4, 9, 14, 19, 24];
+	const excludeA = [4, 17];
+	const excludeB = [2, 12];
+	const includeA = [2, 8, 16, 24];
+	const includeB = [3, 6, 12, 18];
+
+	const spans = EventUtil.eventSequence(framesA, framesB, [excludeA, excludeB], [includeA, includeB]);
+
+	t.deepEqual(spans, [
+		{ start: 5, end: 9 },
+	]);
+});
+
 
 test('EventUtil - pickFromSequence', (t) => {
 	const framesA  = f32(1, 5, 10, 15, 20);

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -66,7 +66,10 @@ export class EventUtil {
 				// If an excluded event is found within the pair, remove the pair.
 				if (excludeFrames) {
 					const exclude = excludeFrames.find(f => f.find(f2 => f2 >= pair.start && f2 <= pair.end));
-					if (exclude) pairs.splice(i, 1);
+					if (exclude) {
+						pairs.splice(i, 1);
+						continue;
+					}
 				}
 
 				// If all included events are not found within the pair, remove the pair.

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -19,12 +19,19 @@ export class EventUtil {
 	 * or higher than the previous end frame, then finds the next
 	 * frame in `toFrames` which is higher than the current start frame.
 	 * 
+	 * If `excludeFrames` is defined, any sequence containing any of these
+	 * frames will be excluded.
+	 * 
+	 * If `includeFrames` is defined, only sequences that contain at least
+	 * one frame from each of the frame arrays will be returned.
+	 * 
 	 * This sequence repeats for all possible pairs.
 	 * @param fromFrames Frames to use as starting frames.
 	 * @param toFrames Frames to use as ending frames.
+	 * @param excludeFrames Frames which invalidates the sequence. Any sequence containing any of these frames will be excluded.
+	 * @param includeFrames Frames which must be present in the sequence. Only sequences that contain at least one frame from each of the frame arrays will be returned.
 	 */
-	static eventSequence(fromFrames: NumericArray, toFrames: NumericArray): IFrameSpan[] {
-		// TODO: add support for required events and excluded events.
+	static eventSequence(fromFrames: NumericArray, toFrames: NumericArray, excludeFrames: NumericArray[] = undefined, includeFrames: NumericArray[] = undefined): IFrameSpan[] {
 		// TODO: Use logic from web report
 
 		// Generate event frame pairs
@@ -47,6 +54,25 @@ export class EventUtil {
 					nextToIndex = j;
 
 					break;
+				}
+			}
+		}
+
+		// Filter out pairs that contain excluded events or does not contain included events.
+		if (excludeFrames || includeFrames) {
+			for (let i = pairs.length - 1; i >= 0; i--) {
+				const pair = pairs[i];
+
+				// If an excluded event is found within the pair, remove the pair.
+				if (excludeFrames) {
+					const exclude = excludeFrames.find(f => f.find(f2 => f2 >= pair.start && f2 <= pair.end));
+					if (exclude) pairs.splice(i, 1);
+				}
+
+				// If all included events are not found within the pair, remove the pair.
+				if (includeFrames) {
+					const include = includeFrames.every(f => f.find(f2 => f2 >= pair.start && f2 <= pair.end));
+					if (!include) pairs.splice(i, 1);
 				}
 			}
 		}


### PR DESCRIPTION
Adds the following options to the `eventDuration` and `eventMask` steps:

>
> #### `exclude`
>
> **Type:** `Number | Number array`  
> **Required:** `False`  
> **Default value:** `null`  
>
> One or more event signals that should invalidate an event
> sequence. If any of these events occur within a sequence,
> the sequence is invalidated.
>
> #### `include`
>
> **Type:** `Number | Number array`  
> **Required:** `False`  
> **Default value:** `null`  
>
> One or more event signals that should be included in an
> event sequence, otherwise it is excluded. If multiple 
> events are supplied, all of them must be present in each
> sequence for it to be included.
>

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

Work item: [AB#31929](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/31929)