### PR TITLE
Ensure positive frames in eventMask step

### DIFF
--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -220,6 +220,27 @@ export class Signal implements IDataSequence {
 	}
 
 	/**
+	 * Returns true if all values in the signal are positive.
+	 */
+	get isPositive(): boolean {
+		switch (this._type) {
+			case SignalType.Uint32Array:
+				return this.getUint32ArrayValue().every(v => v >= 0);
+			case SignalType.Float32:
+				return this.getNumberValue() >= 0;
+			case SignalType.Float32Array:
+				return this.getFloat32ArrayValue().every(v => v >= 0);
+			case SignalType.Float32ArrayArray:
+			case SignalType.Segment:
+			case SignalType.VectorSequence:
+			case SignalType.PlaneSequence:
+				return this.array.every(arr => arr.every(v => v >= 0));
+			default:
+				return undefined;
+		}
+	}
+
+	/**
 	 * Instantiate a [[SignalType]] data structure from an array.
 	 * @param type The intended data type.
 	 * @param array A multi-dimensional array of signal data.

--- a/src/lib/processing/events/event-duration.ts
+++ b/src/lib/processing/events/event-duration.ts
@@ -118,7 +118,7 @@ export class EventDurationStep extends BaseStep {
 		const durations = pairs
 			.map(span => span.end - span.start)
 			.map(frameDur => frameDur / frameRate)
-			;
+		;
 
 		const returnSignal = from.clone(Float32Array.from(durations));
 		returnSignal.frameRate = frameRate;

--- a/src/lib/processing/events/event-mask.spec.ts
+++ b/src/lib/processing/events/event-mask.spec.ts
@@ -46,6 +46,10 @@ test('EventMaskStep - Wrong input signals', async(t) => {
 	await t.throwsAsync(mockStep(EventMaskStep, [e1, e2]).process()); // Too few inputs
 	await t.throwsAsync(mockStep(EventMaskStep, [s3, e1, e2]).process()); // Wrong type
 	await t.throwsAsync(mockStep(EventMaskStep, [s1, s1, s1]).process()); // Wrong type for events
+
+	// Negative event frames
+	await t.throwsAsync(mockStep(EventMaskStep, [s1, new Signal([1, 3, -5]), new Signal([2, 4, 6])]).process());
+	await t.throwsAsync(mockStep(EventMaskStep, [s1, new Signal([1, 3, 5]), new Signal([2, -4, 6])]).process());
 });
 
 test('EventMaskStep - simple array', async(t) => {

--- a/src/lib/processing/events/event-mask.ts
+++ b/src/lib/processing/events/event-mask.ts
@@ -188,6 +188,14 @@ export class EventMaskStep extends BaseStep {
 			throw new ProcessingError('The event mask step expects only events in the include option.');
 		}
 
+		if (!from.isPositive) {
+			throw new ProcessingError('The second input, "from", contains negative frame indices.');
+		}
+
+		if (!to.isPositive) {
+			throw new ProcessingError('The third input, "to", contains negative frame indices.');
+		}
+
 		// Expect a one-dimensional array, round all values and cast into a Uint array.
 		const fromFrames = Uint32Array.from(from.array[0].map(v => Math.round(v)));
 		const toFrames = Uint32Array.from(to.array[0].map(v => Math.round(v)));


### PR DESCRIPTION
This PR adds checks to the `eventMask` step to ensure that all input event frames are positive. If they are not, an error is thrown during processing.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [ ] Documentation added

Work item: [AB#32262](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/32262)