### PR TITLE
eventMask step - ignore out-of-bounds events

### DIFF
--- a/src/lib/processing/events/event-mask.spec.ts
+++ b/src/lib/processing/events/event-mask.spec.ts
@@ -60,6 +60,21 @@ test('EventMaskStep - simple array', async(t) => {
 	t.deepEqual(res.getValue(), comp);
 });
 
+test('EventMaskStep - simple array - out-of-bounds events', async(t) => {
+	const oobEventFrames1 = i32(0, 4, 8);
+	const oobEventFrames2 = i32(2, 6, 15); // 15 is out-of-bounds, the 8-15 cycle should be ignored.
+
+	const oobe1 = new Signal(oobEventFrames1, frameRate);
+	const oobe2 = new Signal(oobEventFrames2, frameRate);
+	oobe1.isEvent = oobe2.isEvent = true;
+
+	const res = await mockStep(EventMaskStep, [s2, oobe1, oobe2]).process();
+	
+	t.is(res.resultType, ResultType.Scalar);
+	t.deepEqual(res.cycles, [{ start: 0, end: 2 }, { start: 4, end: 6 }]);
+	t.deepEqual(res.getValue(), comp);
+});
+
 test('EventMaskStep - event array', async(t) => {
 	const res = await mockStep(EventMaskStep, [s2Event, e1, e2]).process();
 	

--- a/src/lib/processing/events/event-mask.ts
+++ b/src/lib/processing/events/event-mask.ts
@@ -196,9 +196,17 @@ export class EventMaskStep extends BaseStep {
 			throw new ProcessingError('The third input, "to", contains negative frame indices.');
 		}
 
-		// Expect a one-dimensional array, round all values and cast into a Uint array.
-		const fromFrames = Uint32Array.from(from.array[0].map(v => Math.round(v)));
-		const toFrames = Uint32Array.from(to.array[0].map(v => Math.round(v)));
+		// Expect a one-dimensional array, exclude out-of-bounds frames, round all values, and cast into a Uint array.
+		const fromFrames = Uint32Array.from(from
+			.array[0]
+			.filter(v => v <= source.length)
+			.map(v => Math.round(v))
+		);
+		const toFrames = Uint32Array.from(to
+			.array[0]
+			.filter(v => v <= source.length)
+			.map(v => Math.round(v))
+		);
 
 		const excludeFrames = this.exclude?.map(i => i.getEventArrayValue());
 		const includeFrames = this.include?.map(i => i.getEventArrayValue());


### PR DESCRIPTION
This PR changes the behaviour of the `eventMask` step so that cycles that span outside of the measurement frames are discarded.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [ ] Documentation added


Work item: [AB#33262](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/33262)