### PR TITLE
Docs: Changed from using commas to semicolons for field input syntax

### DIFF
--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -174,17 +174,17 @@ _This example shows how to use the `$length` and `$framerate` to calculate the m
 
 - `$field(Field Name)` - returns the value of the **measurement field** specified within the brackets. If no measurement field was found, returns the value of a **session field** of the same name. The name of the field is case sensitive.
 
-- `$field(Field Name, measurement)` - returns the value of the **measurement field** specified within the brackets. The name of the field is case sensitive.
+- `$field(Field Name; measurement)` - returns the value of the **measurement field** specified within the brackets. The name of the field is case sensitive.
 
-- `$field(Field Name, trial)` - the argument `trial` is an alias for `measurement` and returns a **measurement field** value like above.
+- `$field(Field Name; trial)` - the argument `trial` is an alias for `measurement` and returns a **measurement field** value like above.
 
-- `$field(Field Name, session)` - returns the value of the **session field** specified within the brackets. The name of the field is case sensitive.
+- `$field(Field Name; session)` - returns the value of the **session field** specified within the brackets. The name of the field is case sensitive.
 
 ### Value casting
 
 If a field value is fully numeric, it will automatically be cast as a numeric value rather than a string. However, if the value is a number followed by a string – such as a unit – the field value will be treated as a string.
 
-To force the interpretation of the field to be numeric, pass in the value `numeric` as a third parameter to the `field` syntax, like so: `$field(Field Name, measurement, numeric)`.
+To force the interpretation of the field to be numeric, pass in the value `numeric` as a third parameter to the `field` syntax, like so: `$field(Field Name; measurement; numeric)`.
 
 If the value was not able to be parsed as a number, the result will be `NaN`.
 
@@ -195,7 +195,7 @@ If the value was not able to be parsed as a number, the result will be `NaN`.
 ```yaml
 - parameter: Speed_Diff
   steps:
-    - subtract: [$field(Treadmill Speed, measurement), Caclulated_Running_Speed]
+    - subtract: [$field(Treadmill Speed; measurement), Caclulated_Running_Speed]
 ```
 
 _This example shows how to use a `Treadmill Speed` measurement field to calculate the difference between the entered speed and the calculated speed._
@@ -204,8 +204,8 @@ _This example shows how to use a `Treadmill Speed` measurement field to calculat
 - parameter: BMI
   steps:
     - multiply:
-        [$field(Subject Height, session), $field(Subject Height, session)]
-    - divide: [$field(Subject Weight, session), $prev]
+        [$field(Subject Height; session), $field(Subject Height; session)]
+    - divide: [$field(Subject Weight; session), $prev]
 ```
 
 _This example shows how to use the `Subject Height` and `Subject Weight` session fields to calculate the subject BMI._

--- a/docs/nodes/steps/logic.md
+++ b/docs/nodes/steps/logic.md
@@ -127,7 +127,7 @@ otherwise the result is `myDefault`.
 The following example shows how you can compare values from measurement fields.
 
 ``` yaml
-- if: $field(My Field, measurement, numeric) > $field(My Other Field, measurement, numeric)
+- if: $field(My Field; measurement; numeric) > $field(My Other Field; measurement; numeric)
   then: mySignal
   else: myDefault
 ```
@@ -135,8 +135,8 @@ The following example shows how you can compare values from measurement fields.
 The following example shows how to return a field value if it is not empty, otherwise return a default value.
 
 ``` yaml
-- if: "!empty($field(My Field, measurement, numeric))"
-  then: $field(My Field, measurement, numeric)
+- if: "!empty($field(My Field; measurement; numeric))"
+  then: $field(My Field; measurement; numeric)
   else: myDefault
 ```
 


### PR DESCRIPTION
Preparing the documentation for the coming update where the syntax of the field accessor has changed from using commas to use semicolons instead.

Work item: [AB#32435](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/32435)