### PR TITLE
Force plate support in pipelines

### DIFF
--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -8,6 +8,7 @@
       - [Markers](#markers)
       - [Events](#events)
       - [EMG channels](#emg-channels)
+      - [Force plates](#force-plates)
     + [Components](#components)
   * [Mixed inputs](#mixed-inputs)
   * [Variable inputs](#variable-inputs)
@@ -116,6 +117,11 @@ Currently, EMG signals from the following EMG boards are supported:
 * MEGA/ME6000
 * Cometa
 * Delsys Trigno
+
+#### Force plates
+Force plates are made available to the pipeline using the names `ForcePlate1`, `ForcePlate2`, etc. The force plates are renamed from their original name for consistency and they are enumerated in the order they are exported from QTM.
+
+The force plates have components for reading the **center of pressure**, **force**, and **moment**. For more details on how to access these components, [read here](./working-with-data#force-plate).
 
 ### Components
 

--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -123,6 +123,8 @@ Force plates are made available to the pipeline using the names `ForcePlate1`, `
 
 The force plates have components for reading the **center of pressure**, **force**, and **moment**. For more details on how to access these components, [read here](./working-with-data#force-plate).
 
+_**Note:** The force plate data is resampled to the framerate of the skeleton._
+
 ### Components
 
 For named signals with components, such as a segment or marker, you can

--- a/docs/working-with-data.md
+++ b/docs/working-with-data.md
@@ -8,7 +8,8 @@ Calqulus can import the following kinds of data from your measurements:
 * Marker
 * Skeletal (accessible via *segments*)
 * EMG
-* Kinetics (accessible via *joints*).
+* Kinetics (accessible via *joints*)
+* Force plate
 
 ## Importing data
 To access data in a Calqulus pipeline you can either reference it by name
@@ -98,6 +99,16 @@ _Example of multiplying the x and y component of a marker._
 
 **Power**
 * p
+
+### Force plate
+**Center of pressure**
+* x, y, z
+
+**Force**
+* fx, fy, fz
+
+**Moment**
+* mx, my, mz
 
 ## Quick reference
 ### Segments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calqulus-steps",
-  "version": "1.2.0",
+  "version": "1.2.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calqulus-steps",
-      "version": "1.2.0",
+      "version": "1.2.0-beta.10",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/parser": "^5.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calqulus-steps",
-  "version": "1.2.0",
+  "version": "1.2.0-beta.10",
   "description": "Processing steps for Calqulus - Qualisys online processing engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export * from './lib/utils/convert';
 export * from './lib/utils/events';
 export * from './lib/utils/expression';
 export * from './lib/utils/input-duration';
+export * from './lib/utils/interpolation';
 export * from './lib/utils/number';
 export * from './lib/utils/processing-error';
 export * from './lib/utils/reference-signal';

--- a/src/lib/models/force-plate.spec.ts
+++ b/src/lib/models/force-plate.spec.ts
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import { f32 } from '../../test-utils/mock-step';
+
 import { ForcePlate } from './force-plate';
+import { VectorSequence } from './sequence/vector-sequence';
 
 const corners = [
 	{ x: 0, y: 0, z: 0 },
@@ -9,16 +12,48 @@ const corners = [
 	{ x: 1, y: 0, z: 0 },
 ];
 
-const fp = new ForcePlate('forceplate 1', corners, 100, 200, { x: 0, y: 0, z: 0 }, 10, true);
+const cop = new VectorSequence(f32(1, 2, 3), f32(4, 5, 6), f32(7, 8, 9), 100);
+const force = new VectorSequence(f32(1, 2, 3), f32(4, 5, 6), f32(7, 8, 9), 100);
+const moment = new VectorSequence(f32(1, 2, 3), f32(4, 5, 6), f32(7, 8, 9), 100);
+
+const fp = new ForcePlate('forceplate 1', cop, force, moment);
+
+fp.corners = corners;
+fp.dimensions = {
+	width: 100,
+	length: 200,
+};
+fp.offset = { x: 0, y: 0, z: 0 };
+fp.copLevelZ = 10;
+fp.copFilter = true;
 
 test('ForcePlate - constructor', (t) => {
 	t.is(fp.name, 'forceplate 1');
+	
+	t.is(fp.centerOfPressure, cop);
+	t.is(fp.force, force);
+	t.is(fp.moment, moment);
+
 	t.is(fp.corners, corners);
-	t.is(fp.width, 100);
-	t.is(fp.length, 200);
+	t.is(fp.dimensions.width, 100);
+	t.is(fp.dimensions.length, 200);
 	t.deepEqual(fp.offset, { x: 0, y: 0, z: 0 });
 	t.is(fp.copLevelZ, 10);
 	t.is(fp.copFilter, true);
+
+	t.is(fp.length, 3);
+
+	t.is(fp.x, cop.x);
+	t.is(fp.y, cop.y);
+	t.is(fp.z, cop.z);
+
+	t.is(fp.fx, force.x);
+	t.is(fp.fy, force.y);
+	t.is(fp.fz, force.z);
+
+	t.is(fp.mx, moment.x);
+	t.is(fp.my, moment.y);
+	t.is(fp.mz, moment.z);
 });
 
 test('ForcePlate - setMetadata', (t) => {
@@ -32,4 +67,67 @@ test('ForcePlate - setMetadata', (t) => {
 	t.is(fp.serial, '123');
 	t.is(fp.amplifierSerial, '456');
 	t.is(fp.coordinateSystem, 'world');
+});
+
+test('ForcePlate - reassign sequence data', (t) => {
+	const fp2 = new ForcePlate('forceplate 1', cop, force, moment);
+
+	t.is(fp2.centerOfPressure, cop);
+	t.is(fp2.force, force);
+	t.is(fp2.moment, moment);
+	t.deepEqual(fp2.array, [
+		f32(1, 2, 3),
+		f32(4, 5, 6),
+		f32(7, 8, 9),
+		f32(1, 2, 3),
+		f32(4, 5, 6),
+		f32(7, 8, 9),
+		f32(1, 2, 3),
+		f32(4, 5, 6),
+		f32(7, 8, 9),
+	]);
+
+	t.is(fp2.x, cop.x);
+	t.is(fp2.y, cop.y);
+	t.is(fp2.z, cop.z);
+
+	t.is(fp2.fx, force.x);
+	t.is(fp2.fy, force.y);
+	t.is(fp2.fz, force.z);
+
+	t.is(fp2.mx, moment.x);
+	t.is(fp2.my, moment.y);
+	t.is(fp2.mz, moment.z);
+
+	t.is(fp2.frameRate, 100);
+
+	fp2.centerOfPressure = new VectorSequence(f32(10, 20, 30), f32(40, 50, 60), f32(70, 80, 90), 1000);
+	fp2.force = new VectorSequence(f32(100, 200, 300), f32(400, 500, 600), f32(700, 800, 900), 1000);
+	fp2.moment = new VectorSequence(f32(1000, 2000, 3000), f32(4000, 5000, 6000), f32(7000, 8000, 9000), 1000);
+
+	t.deepEqual(fp2.array, [
+		f32(10, 20, 30),
+		f32(40, 50, 60),
+		f32(70, 80, 90),
+		f32(100, 200, 300),
+		f32(400, 500, 600),
+		f32(700, 800, 900),
+		f32(1000, 2000, 3000),
+		f32(4000, 5000, 6000),
+		f32(7000, 8000, 9000),
+	]);
+
+	t.is(fp2.x, fp2.centerOfPressure.x);
+	t.is(fp2.y, fp2.centerOfPressure.y);
+	t.is(fp2.z, fp2.centerOfPressure.z);
+
+	t.is(fp2.fx, fp2.force.x);
+	t.is(fp2.fy, fp2.force.y);
+	t.is(fp2.fz, fp2.force.z);
+
+	t.is(fp2.mx, fp2.moment.x);
+	t.is(fp2.my, fp2.moment.y);
+	t.is(fp2.mz, fp2.moment.z);
+
+	t.is(fp2.frameRate, 1000);
 });

--- a/src/lib/models/force-plate.spec.ts
+++ b/src/lib/models/force-plate.spec.ts
@@ -131,3 +131,23 @@ test('ForcePlate - reassign sequence data', (t) => {
 
 	t.is(fp2.frameRate, 1000);
 });
+
+test('ForcePlate - getComponent', (t) => {
+	t.deepEqual(fp.getComponent('x'), fp.x);
+	t.deepEqual(fp.getComponent('y'), fp.y);
+	t.deepEqual(fp.getComponent('z'), fp.z);
+	t.deepEqual(fp.getComponent('fx'), fp.fx);
+	t.deepEqual(fp.getComponent('fy'), fp.fy);
+	t.deepEqual(fp.getComponent('fz'), fp.fz);
+	t.deepEqual(fp.getComponent('mx'), fp.mx);
+	t.deepEqual(fp.getComponent('my'), fp.my);
+	t.deepEqual(fp.getComponent('mz'), fp.mz);
+});
+
+test('ForcePlate - from array', (t) => {
+	const array = fp.array;
+	const fp2 = ForcePlate.fromArray('forceplate 2', array);
+
+	t.is(fp2.name, 'forceplate 2');
+	t.deepEqual(fp2.array, array);
+});

--- a/src/lib/models/force-plate.ts
+++ b/src/lib/models/force-plate.ts
@@ -1,25 +1,83 @@
+import { IDataSequence, ISequence } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 import { IVector } from './spatial/vector';
 
-export class ForcePlate {
+export class ForcePlate implements ISequence, IDataSequence {
+	array: TypedArray[];
+	components = ['x', 'y', 'z', 'fx', 'fy', 'fz', 'mx', 'my', 'mz'];
+
+	corners: IVector[];
+	dimensions: { width: number, length: number };
+	offset: IVector;
+	copLevelZ: number;
+	copFilter: boolean;
+
+	originalName: string | null = null;
 	amplifierSerial: string | null = null;
-	centerOfPressure: VectorSequence;
 	coordinateSystem: string | null = null;
-	force: VectorSequence;
 	model: string | null = null;
-	moment: VectorSequence;
 	serial: string | null = null;
 	type: string | null = null;
 
+
 	constructor(
 		public name: string,
-		public corners: IVector[],
-		public width: number,
-		public length: number,
-		public offset: IVector,
-		public copLevelZ: number,
-		public copFilter: boolean
+		protected _centerOfPressure: VectorSequence,
+		protected _force: VectorSequence,
+		protected _moment: VectorSequence,
 	) {
+		this.array = [
+			...this._centerOfPressure.array,
+			...this._force.array,
+			...this._moment.array,
+		];
+	}
+
+	get length() {
+		return this.force.length;
+	}
+
+	get centerOfPressure(): VectorSequence { return this._centerOfPressure; }
+
+	set centerOfPressure(value: VectorSequence) {
+		this._centerOfPressure = value;
+		this.array[0] = value.x;
+		this.array[1] = value.y;
+		this.array[2] = value.z;
+	}
+
+	get force(): VectorSequence { return this._force; }
+
+	set force(value: VectorSequence) {
+		this._force = value;
+		this.array[3] = value.x;
+		this.array[4] = value.y;
+		this.array[5] = value.z;
+	}
+
+	get moment(): VectorSequence { return this._moment; }
+
+	set moment(value: VectorSequence) {
+		this._moment = value;
+		this.array[6] = value.x;
+		this.array[7] = value.y;
+		this.array[8] = value.z;
+	}
+
+	get x(): TypedArray { return this._centerOfPressure.x; }
+	get y(): TypedArray { return this._centerOfPressure.y; }
+	get z(): TypedArray { return this._centerOfPressure.z; }
+
+	get fx(): TypedArray { return this._force.x; }
+	get fy(): TypedArray { return this._force.y; }
+	get fz(): TypedArray { return this._force.z; }
+
+	get mx(): TypedArray { return this._moment.x; }
+	get my(): TypedArray { return this._moment.y; }
+	get mz(): TypedArray { return this._moment.z; }
+
+	get frameRate() {
+		return this.force.frameRate;
 	}
 
 	public setMetadata(type: string, model: string, serial: string, amplifierSerial: string, coordinateSystem: string) {
@@ -28,5 +86,27 @@ export class ForcePlate {
 		this.model = model;
 		this.serial = serial;
 		this.type = type;
+	}
+
+	getComponent(component: string): TypedArray {
+		const index = this.components.indexOf(component);
+
+		return this.array[index];
+	}
+
+	/**
+	 * Returns a [[ForcePlate]] from an array, where 
+	 * `x`, `y`, `z`, `fx`, `fy`, `fz`, `mx`, `my`, `mz` are included.
+	 * @param param0 
+	 */
+	static fromArray(name: string, [x, y, z, fx, fy, fz, mx, my, mz]: TypedArray[]) {
+		const fp = new ForcePlate(
+			name, 
+			VectorSequence.fromArray('cop', [x, y, z]),
+			VectorSequence.fromArray('force', [fx, fy, fz]),
+			VectorSequence.fromArray('moment', [mx, my, mz]),
+		);
+
+		return fp;
 	}
 }

--- a/src/lib/models/signal.spec.ts
+++ b/src/lib/models/signal.spec.ts
@@ -3,6 +3,7 @@ import test from 'ava';
 import { f32, i32, mockStep } from '../../test-utils/mock-step';
 import { Space } from '../processing/space';
 
+import { ForcePlate } from './force-plate';
 import { Joint } from './joint';
 import { Marker } from './marker';
 import { Segment } from './segment';
@@ -27,6 +28,7 @@ const segment = new Segment('head', vecSeq, quatSeq, frameRate);
 const joint = new Joint('LeftKnee', vecSeq, vecSeq, undefined, undefined, 100);
 const joint2 = new Joint('LeftKnee', vecSeq, vecSeq, vecSeq, fakeArray, 100);
 const plane = new PlaneSequence(fakeArray, fakeArray, fakeArray, fakeArray);
+const forcePlate = new ForcePlate('test', vecSeq, vecSeq, vecSeq);
 
 // Signal variants
 const s1_uintarr = new Signal(fakeUIntArray, frameRate);
@@ -54,6 +56,8 @@ const s1_marker = new Signal(markerSeq, frameRate);
 const s2_marker = new Signal().setValue(markerSeq);
 const s1_undef = new Signal(undefined, frameRate);
 const s2_undef = new Signal().setValue(undefined);
+const s1_fp = new Signal(forcePlate, frameRate);
+const s2_fp = new Signal().setValue(forcePlate);
 
 // Example cycles
 const cycles = [{
@@ -138,6 +142,15 @@ test('Signal - Joint constructor', (t) => {
 	t.is(s1_joint.length, joint.length);
 	t.is(s1_joint.getValue(), joint);
 	t.is(s1_joint.components, joint.components);
+});
+
+test('Signal - Force Plate constructor', (t) => {
+	t.assert(s1_fp.type === s2_fp.type && s1_fp.type === SignalType.ForcePlate);
+	t.is(s1_fp.typeToString, 'ForcePlate');
+	t.is(s1_fp.frameRate, frameRate);
+	t.is(s1_fp.length, vecSeq.length);
+	t.is(s1_fp.getValue(), forcePlate);
+	t.is(s1_fp.components, forcePlate.components);
 });
 
 test('Signal - String constructor', (t) => {
@@ -246,6 +259,18 @@ test('Signal - typeFromArray', (t) => {
 		px: joint.p
 	});
 
+	t.like(Signal.typeFromArray(SignalType.ForcePlate, forcePlate.array), {
+		x: forcePlate.x,
+		y: forcePlate.y,
+		z: forcePlate.z,
+		fx: forcePlate.fx,
+		fy: forcePlate.fy,
+		fz: forcePlate.fz,
+		mx: forcePlate.mx,
+		my: forcePlate.my,
+		mz: forcePlate.mz,
+	});
+
 	t.like(Signal.typeFromArray(SignalType.Segment, segment.array), {
 		x: segment.x,
 		y: segment.y,
@@ -285,6 +310,7 @@ test('Signal - array', (t) => {
 	t.deepEqual(s1_f32arrarr.array, fakeNestedArray);
 	t.deepEqual(s1_numarr.array, [fakeArray]);
 	t.deepEqual(s1_segment.array, segment.array);
+	t.deepEqual(s1_fp.array, forcePlate.array);
 	t.deepEqual(s1_string.array, undefined);
 	t.deepEqual(s1_vecseq.array, vecSeq.array);
 	t.deepEqual(s1_marker.array, vecSeq.array);
@@ -317,6 +343,7 @@ test('Signal - getting values', (t) => {
 	t.is(s1_f32arrarr.getFloat32ArrayArrayValue(), fakeNestedArray);
 	t.deepEqual(s1_numarr.getFloat32ArrayValue(), fakeArray);
 	t.is(s1_joint.getJointValue(), joint);
+	t.is(s1_fp.getForcePlateValue(), forcePlate);
 	t.is(s1_segment.getSegmentValue(), segment);
 	t.is(s1_string.getStringValue(), testString);
 	t.is(s1_vecseq.getVectorSequenceValue(), vecSeq);
@@ -358,6 +385,16 @@ test('Signal - getComponent', (t) => {
 	t.is(s1_joint2.getComponent('mz'), fakeArray);
 	t.is(s1_joint2.getComponent('p'), fakeArray);
 
+	t.is(s1_fp.getComponent('x'), fakeArray);
+	t.is(s1_fp.getComponent('y'), fakeArray);
+	t.is(s1_fp.getComponent('z'), fakeArray);
+	t.is(s1_fp.getComponent('fx'), fakeArray);
+	t.is(s1_fp.getComponent('fy'), fakeArray);
+	t.is(s1_fp.getComponent('fz'), fakeArray);
+	t.is(s1_fp.getComponent('mx'), fakeArray);
+	t.is(s1_fp.getComponent('my'), fakeArray);
+	t.is(s1_fp.getComponent('mz'), fakeArray);
+
 	// Wrong component names
 	t.is(s1_segment.getComponent('wrong'), undefined);
 	t.is(s1_vecseq.getComponent('nonexistent'), undefined);
@@ -395,6 +432,17 @@ test('Signal - getFrames', (t) => {
 		undefined, undefined, undefined,
 		undefined
 	]);
+
+	// Force plate
+	const fpFrames = s1_fp.getFrames(frames);
+
+	// Position, force, moment.
+	t.deepEqual(fpFrames.array.map((a => a === undefined ? undefined : Array.from(a))), [
+		Array.from(frameValueComp), Array.from(frameValueComp), Array.from(frameValueComp),
+		Array.from(frameValueComp), Array.from(frameValueComp), Array.from(frameValueComp),
+		Array.from(frameValueComp), Array.from(frameValueComp), Array.from(frameValueComp),
+	]);
+
 
 	// Vector
 	const vecFrames = s1_vecseq.getFrames(frames);

--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -2,6 +2,7 @@ import { range } from 'lodash';
 
 import { Space } from '../processing/space';
 
+import { ForcePlate } from './force-plate';
 import { Joint } from './joint';
 import { Marker } from './marker';
 import { Segment } from './segment';
@@ -18,6 +19,7 @@ class SignalValue {
 	numberArray: Float32Array = new Float32Array(0);
 	numberArrayArray: Float32Array[] = [];
 	joint: Joint | null;
+	forcePlate: ForcePlate | null;
 	segment: Segment | null;
 	vectorSequence: VectorSequence | null;
 	planeSequence: PlaneSequence | null;
@@ -33,6 +35,7 @@ export enum SignalType {
 	Float32Array,
 	Float32ArrayArray,
 	Joint,
+	ForcePlate,
 	Segment,
 	String,
 	VectorSequence,
@@ -145,6 +148,8 @@ export class Signal implements IDataSequence {
 				return 'Float32Array[]';
 			case SignalType.Joint:
 				return 'Joint';
+			case SignalType.ForcePlate:
+				return 'ForcePlate';
 			case SignalType.Segment:
 				return 'Segment';
 			case SignalType.String:
@@ -171,6 +176,7 @@ export class Signal implements IDataSequence {
 
 			case SignalType.Float32ArrayArray:
 			case SignalType.Joint:
+			case SignalType.ForcePlate:
 			case SignalType.Segment:
 			case SignalType.VectorSequence:
 			case SignalType.PlaneSequence:
@@ -203,6 +209,8 @@ export class Signal implements IDataSequence {
 				return this.getFloat32ArrayArrayValue();
 			case SignalType.Joint:
 				return this._value.joint.array;
+			case SignalType.ForcePlate:
+				return this._value.forcePlate.array;
 			case SignalType.Segment:
 				return this._value.segment.array;
 			case SignalType.String:
@@ -265,6 +273,8 @@ export class Signal implements IDataSequence {
 				return array;
 			case SignalType.Joint:
 				return Joint.fromArray(undefined, array);
+			case SignalType.ForcePlate:
+				return ForcePlate.fromArray(undefined, array);
 			case SignalType.Segment:
 				return Segment.fromArray(undefined, array);
 			case SignalType.String:
@@ -293,6 +303,8 @@ export class Signal implements IDataSequence {
 			}
 			case SignalType.Joint:
 				return this._value.joint.length;
+			case SignalType.ForcePlate:
+				return this._value.forcePlate.length;
 			case SignalType.Segment:
 				return this._value.segment.length;
 			case SignalType.String:
@@ -387,6 +399,10 @@ export class Signal implements IDataSequence {
 			this._value.joint = value;
 			this._type = SignalType.Joint;
 		}
+		else if (value instanceof ForcePlate) {
+			this._value.forcePlate = value;
+			this._type = SignalType.ForcePlate;
+		}
 		else if (value instanceof Segment) {
 			this._value.segment = value;
 			this._type = SignalType.Segment;
@@ -409,6 +425,8 @@ export class Signal implements IDataSequence {
 		if (this._type !== SignalType.Uint32Array) this._value.uint32Array = new Uint32Array(0);
 		if (this._type !== SignalType.Float32Array) this._value.numberArray = new Float32Array(0);
 		if (this._type !== SignalType.Float32ArrayArray) this._value.numberArrayArray = [];
+		if (this._type !== SignalType.Joint) this._value.joint = undefined;
+		if (this._type !== SignalType.ForcePlate) this._value.forcePlate = undefined;
 		if (this._type !== SignalType.Segment) this._value.segment = undefined;
 		if (this._type !== SignalType.VectorSequence) this._value.vectorSequence = undefined;
 		if (this._type !== SignalType.PlaneSequence) this._value.planeSequence = undefined;
@@ -442,6 +460,10 @@ export class Signal implements IDataSequence {
 	}
 	getJointValue(): Joint | null {
 		return this._value.joint;
+	}
+
+	getForcePlateValue(): ForcePlate | null {
+		return this._value.forcePlate;
 	}
 
 	getSegmentValue(): Segment | null {
@@ -495,6 +517,9 @@ export class Signal implements IDataSequence {
 		if (this._type === SignalType.Joint) {
 			return this._value.joint.getComponent(component);
 		}
+		else if (this._type === SignalType.ForcePlate) {
+			return this._value.forcePlate.getComponent(component);
+		}
 		else if (this._type === SignalType.Segment) {
 			return this._value.segment.getComponent(component);
 		}
@@ -523,6 +548,8 @@ export class Signal implements IDataSequence {
 				return this.getFloat32ArrayArrayValue();
 			case SignalType.Joint:
 				return this.getJointValue();
+			case SignalType.ForcePlate:
+				return this.getForcePlateValue();
 			case SignalType.Segment:
 				return this.getSegmentValue();
 			case SignalType.String:
@@ -598,6 +625,7 @@ export class Signal implements IDataSequence {
 
 		switch (this.type) {
 			case SignalType.Joint:
+			case SignalType.ForcePlate:
 			case SignalType.Segment:
 			case SignalType.PlaneSequence:
 			case SignalType.VectorSequence: {
@@ -609,6 +637,9 @@ export class Signal implements IDataSequence {
 				}
 				else if (this.type === SignalType.Joint) {
 					return returnSignal.setValue(Joint.fromArray(this.name, pickedValues), frames);
+				}
+				else if (this.type === SignalType.ForcePlate) {
+					return returnSignal.setValue(ForcePlate.fromArray(this.name, pickedValues), frames);
 				}
 				else if (this.type === SignalType.PlaneSequence) {
 					return returnSignal.setValue(PlaneSequence.fromArray(pickedValues), frames);
@@ -685,7 +716,7 @@ export class Signal implements IDataSequence {
 				this.space = this.targetSpace;
 				this.targetSpace = undefined;
 			}
-			// TODO: implement support for joint and plane?
+			// TODO: implement support for joint and plane and force plate?
 		}
 	}
 

--- a/src/lib/processing/algorithms/base-algorithm.ts
+++ b/src/lib/processing/algorithms/base-algorithm.ts
@@ -1,6 +1,4 @@
-import { Marker } from '../../models/marker';
-import { Segment } from '../../models/segment';
-import { Signal, SignalType } from '../../models/signal';
+import { Signal } from '../../models/signal';
 import { StepCategory } from '../../step-registry';
 import { ProcessingError } from '../../utils/processing-error';
 import { markdownFmt } from '../../utils/template-literal-tags';
@@ -45,23 +43,13 @@ export class BaseAlgorithmStep extends BaseStep {
 		const out = this.inputs[0].clone(false);
 		const originalType = this.inputs[0].type;
 
-		switch (originalType) {
-			case SignalType.Float32:
-				out.setValue(res[0][0]);
-				break;
-			case SignalType.Float32Array:
-			case SignalType.Uint32Array:
-				out.setValue(res[0]);
-				break;
-			case SignalType.VectorSequence:
-				out.setValue(Marker.fromArray(this.inputs[0].name, res as TypedArray[]));
-				break;
-			case SignalType.Segment:
-				// TODO: Should probably not work on segments.
-				out.setValue(Segment.fromArray(this.inputs[0].name, res as TypedArray[]));
-				break;
-			default:
-				out.setValue(res);
+		const outValue = Signal.typeFromArray(originalType, res);
+
+		if (outValue !== undefined) {
+			out.setValue(outValue);
+		}
+		else {
+			out.setValue(res);
 		}
 
 		return out;

--- a/src/lib/processing/events/event-mask.ts
+++ b/src/lib/processing/events/event-mask.ts
@@ -1,6 +1,4 @@
-import { Marker } from '../../models/marker';
 import { PropertyType } from '../../models/property';
-import { Segment } from '../../models/segment';
 import { ResultType, Signal, SignalType } from '../../models/signal';
 import { StepClass } from '../../step-registry';
 import { EventUtil } from '../../utils/events';
@@ -313,13 +311,16 @@ export class EventMaskStep extends BaseStep {
 			returnSignal.cycles = filteredFrames[0].mask;
 		}
 
-		switch (source.type) {
-			case SignalType.Segment:
-				return returnSignal.setValue(Segment.fromArray(source.name, filteredFrames.map(f => f ? f.series as TypedArray : undefined)));
-			case SignalType.VectorSequence:
-				return returnSignal.setValue(Marker.fromArray(source.name, filteredFrames.map(f => f.series as TypedArray)));
-			default:
-				return returnSignal.setValue(filteredFrames.map(f => f ? f.series as TypedArray : undefined));
+		const outputData = filteredFrames.map(f => f ? f.series as TypedArray : undefined);
+		const outValue = Signal.typeFromArray(source.type, outputData);
+
+		if (outValue !== undefined) {
+			returnSignal.setValue(outValue);
 		}
+		else {
+			returnSignal.setValue(outputData);
+		}
+
+		return returnSignal;
 	}
 }

--- a/src/lib/utils/interpolation.spec.ts
+++ b/src/lib/utils/interpolation.spec.ts
@@ -1,0 +1,33 @@
+import test from 'ava';
+
+import { Interpolation } from './interpolation';
+
+const testData1 = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const testData2 = new Float32Array([1, 2, NaN, NaN, 5, NaN, 7, 8, 9, 10]);
+const testData3 = new Float32Array([NaN, NaN, NaN]);
+const testData4 = new Float32Array([NaN, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const testData5 = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, NaN]);
+const testData6 = new Float32Array([NaN, 2, 3, 4, 5, 6, 7, 8, 9, NaN]);
+
+test('Interpolation - lerpArray - Upsampling', async(t) => {
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData1, 19)), [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10]);
+});
+
+test('Interpolation - lerpArray - Downsampling', async(t) => {
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData1, 5)), [1, 3.25, 5.5, 7.75, 10]);
+});
+
+test('Interpolation - lerpArray - With gaps', async(t) => {
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData2, 19)), [1, 1.5, 2, NaN, NaN, NaN, NaN, NaN, 5, NaN, NaN, NaN, 7, 7.5, 8, 8.5, 9, 9.5, 10]);
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData2, 5)), [1, NaN, NaN, 7.75, 10]);
+});
+
+test('Interpolation - lerpArray - Array of NaNs', async(t) => {
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData3, 5)), [NaN, NaN, NaN, NaN, NaN]);
+});
+
+test('Interpolation - lerpArray - NaN at ends', async(t) => {
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData4, 19)), [NaN, NaN, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10]);
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData5, 19)), [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, NaN, NaN]);
+	t.deepEqual(Array.from(Interpolation.lerpArray(testData6, 19)), [NaN, NaN, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, NaN, NaN]);
+});

--- a/src/lib/utils/interpolation.ts
+++ b/src/lib/utils/interpolation.ts
@@ -1,0 +1,28 @@
+export class Interpolation {
+
+	static lerp(x: number, y: number, a: number) {
+		return x * (1 - a) + y * a;
+	}
+
+	public static lerpArray(a: TypedArray, length: number): TypedArray {
+		const k = (a.length - 1.0) / (length - 1.0);
+		const out = new Float32Array(length);
+
+		for (let i = 0; i < length; i++) {
+			// Calculate the exact position in the original array.
+			const exactPos = k * i;
+        
+			// Calculate the indices to interpolate between.
+			const indexLower = Math.floor(exactPos);
+			const indexUpper = Math.min(Math.ceil(exactPos), a.length - 1);
+        
+			// Calculate the interpolation factor
+			const alpha = exactPos - indexLower;
+
+			// Interpolate and store in the result array
+			out[i] = this.lerp(a[indexLower], a[indexUpper], alpha);
+		}
+
+		return out;
+	}
+}

--- a/src/lib/utils/math/arithmetic.spec.ts
+++ b/src/lib/utils/math/arithmetic.spec.ts
@@ -84,6 +84,10 @@ test('Arithmetic - Array and multi-dimensional array with mis-matching number of
 	t.deepEqual(Arithmetic.applyOp(f32(4, 5), [f32(0, 1, 2), f32(3, 4, 5), f32(6, 7, 8)], ArithmeticOp.Add), [f32(4, 5, 6), f32(8, 9, 10)]);
 });
 
+test('Arithmetic - Unsigned integer array, ensure float array is returned when result is negative', (t) => {
+	t.deepEqual(Arithmetic.applyOp(Uint32Array.from([1, 2, 3]), 5, ArithmeticOp.Subtract), f32(-4, -3, -2));
+});
+
 test('Arithmetic - Return types', (t) => {
 	t.true(typeof Arithmetic.applyOp(1, 2, ArithmeticOp.Add) === 'number');
 	t.true(Arithmetic.applyOp(f32(1, 2, 3), 2, ArithmeticOp.Add) instanceof Float32Array);


### PR DESCRIPTION
This PR adds the ability to access force plate data in the pipelines.

Force plates are made available to the pipeline using the names `ForcePlate1`, `ForcePlate2`, etc. The force plates are renamed from their original name for consistency and they are enumerated in the order they are exported from QTM.

The force plates have components for reading the **center of pressure**, **force**, and **moment** using the following component names:

#### Center of pressure
* x, y, z

#### Force
* fx, fy, fz

#### Moment
* mx, my, mz

_**Note:** The force plate data is resampled to the framerate of the skeleton._

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Example
Show example in yaml file...

``` yaml
- parameter: FP1_y
  where:
    name: Cycling*
  steps:
    - import: ForcePlate1.fy
```

Work item: [AB#35126](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/35126)