### PR TITLE
Handle out-of-order events

### DIFF
--- a/docs/nodes/steps/data-structure.md
+++ b/docs/nodes/steps/data-structure.md
@@ -21,6 +21,18 @@ in various ways.
 
 **Output:** `Scalar | Series | Event | Number`
 
+**Options**
+>
+> #### `sort`
+>
+> **Type:** `String`  
+> **Required:** `False`  
+> **Allowed values:** `asc | desc`  
+> **Default value:** `null`  
+>
+> If defined, the resulting array(s) will be sorted by value in ascending 
+> or descending order.
+>
 
 **Shared options**
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calqulus-steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calqulus-steps",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/parser": "^5.27.0",
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001564",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-      "integrity": "sha1-6qi7xYwMvM3Le0EYbfOd0rpZGIk=",
+      "version": "1.0.30001621",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
+      "integrity": "sha1-Sty0Q8i5yDA+BEmDGPmHYWuP6i4=",
       "dev": true,
       "funding": [
         {
@@ -10134,9 +10134,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001564",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-      "integrity": "sha1-6qi7xYwMvM3Le0EYbfOd0rpZGIk=",
+      "version": "1.0.30001621",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
+      "integrity": "sha1-Sty0Q8i5yDA+BEmDGPmHYWuP6i4=",
       "dev": true
     },
     "cbor": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calqulus-steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Processing steps for Calqulus - Qualisys online processing engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/regression-test-versions.json
+++ b/regression-test-versions.json
@@ -6,10 +6,10 @@
 		"toolbelt": "main"
 	},
 	"reference": {
-		"engine": "a348dda6e2d87de93faeda5f2111dcee8cb90e92",
-		"steps": "d1d2ce59c90e230d4d218db5b038967c1f03c2e9",
+		"engine": "6f0b9af34ab8deb9b90f386c2a5ebba13088a89e",
+		"steps": "2c9e0a56d6b523aff3823ba927547967f0d2ad04",
 		"pipelines": "08d038b2b97039287a902f464ef3ae21f3a07eaf",
-		"toolbelt": "369b23c9eed2e7cc9055ee48e4d887b059609510"
+		"toolbelt": "6b777faf563b4007c728ddaae1e844a0956c7e4e"
 	},
 	"lastSuccessful": {
 		"engine": "main",

--- a/regression-test-versions.json
+++ b/regression-test-versions.json
@@ -2,14 +2,14 @@
 	"ci": "main",
 	"current": {
 		"engine": "feature/force-plate",
-		"pipelines": "0f4a6684dafcb9a5ee9ab0eedb1932b2b34c606f",
+		"pipelines": "08d038b2b97039287a902f464ef3ae21f3a07eaf",
 		"toolbelt": "feature/inverse-dynamics"
 	},
 	"reference": {
-      "engine": "4a8c9bc04131f1094337c859485f2a61d86ec249",
-      "steps": "55f4d456891fa6286f33dae564ca0f35e5ce8def",
-      "pipelines": "ffadbfae5079ebd750209e2633480ac6471f548a",
-      "toolbelt": "6b777faf563b4007c728ddaae1e844a0956c7e4e"
+		"engine": "a348dda6e2d87de93faeda5f2111dcee8cb90e92",
+		"steps": "d1d2ce59c90e230d4d218db5b038967c1f03c2e9",
+		"pipelines": "08d038b2b97039287a902f464ef3ae21f3a07eaf",
+		"toolbelt": "369b23c9eed2e7cc9055ee48e4d887b059609510"
 	},
 	"lastSuccessful": {
 		"engine": "main",

--- a/regression-test-versions.json
+++ b/regression-test-versions.json
@@ -6,10 +6,10 @@
 		"toolbelt": "feature/inverse-dynamics"
 	},
 	"reference": {
-		"engine": "a348dda6e2d87de93faeda5f2111dcee8cb90e92",
-		"steps": "d1d2ce59c90e230d4d218db5b038967c1f03c2e9",
-		"pipelines": "0f4a6684dafcb9a5ee9ab0eedb1932b2b34c606f",
-		"toolbelt": "369b23c9eed2e7cc9055ee48e4d887b059609510"
+      "engine": "4a8c9bc04131f1094337c859485f2a61d86ec249",
+      "steps": "55f4d456891fa6286f33dae564ca0f35e5ce8def",
+      "pipelines": "ffadbfae5079ebd750209e2633480ac6471f548a",
+      "toolbelt": "6b777faf563b4007c728ddaae1e844a0956c7e4e"
 	},
 	"lastSuccessful": {
 		"engine": "main",

--- a/regression-test-versions.json
+++ b/regression-test-versions.json
@@ -1,9 +1,9 @@
 {
 	"ci": "main",
 	"current": {
-		"engine": "feature/force-plate",
+		"engine": "main",
 		"pipelines": "08d038b2b97039287a902f464ef3ae21f3a07eaf",
-		"toolbelt": "feature/inverse-dynamics"
+		"toolbelt": "main"
 	},
 	"reference": {
 		"engine": "a348dda6e2d87de93faeda5f2111dcee8cb90e92",

--- a/src/lib/models/analog.ts
+++ b/src/lib/models/analog.ts
@@ -1,6 +1,8 @@
 import { IDataSequence, ISequence } from './sequence/sequence';
 
 export class Analog implements ISequence, IDataSequence {
+	readonly typeName = 'Analog';
+
 	array = [this.signal];
 	components = ['signal'];
 
@@ -19,5 +21,10 @@ export class Analog implements ISequence, IDataSequence {
 		const index = this.components.indexOf(component);
 
 		return this.array[index];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isAnalog(object: any): object is Analog {
+		return object?.typeName === 'Analog';
 	}
 }

--- a/src/lib/models/force-plate.ts
+++ b/src/lib/models/force-plate.ts
@@ -3,6 +3,8 @@ import { VectorSequence } from './sequence/vector-sequence';
 import { IVector } from './spatial/vector';
 
 export class ForcePlate implements ISequence, IDataSequence {
+	readonly typeName = 'ForcePlate';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'fx', 'fy', 'fz', 'mx', 'my', 'mz'];
 
@@ -108,5 +110,10 @@ export class ForcePlate implements ISequence, IDataSequence {
 		);
 
 		return fp;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isForcePlate(object: any): object is ForcePlate {
+		return object?.typeName === 'ForcePlate';
 	}
 }

--- a/src/lib/models/joint.ts
+++ b/src/lib/models/joint.ts
@@ -3,6 +3,8 @@ import { IDataSequence, ISequence } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 
 export class Joint implements ISequence, IDataSequence {
+	readonly typeName = 'Joint';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'fx', 'fy', 'fz', 'mx', 'my', 'mz', 'p'];
 	distalSegment: Segment;
@@ -92,5 +94,10 @@ export class Joint implements ISequence, IDataSequence {
 	 */
 	static fromArray(name: string, [x, y, z, fx, fy, fz, mx, my, mz, p]: TypedArray[]) {
 		return new Joint(name, new VectorSequence(x, y, z), new VectorSequence(fx, fy, fz), new VectorSequence(mx, my, mz), p as Float32Array);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isJoint(object: any): object is Joint {
+		return object?.typeName === 'Joint';
 	}
 }

--- a/src/lib/models/marker.ts
+++ b/src/lib/models/marker.ts
@@ -2,6 +2,7 @@ import { IDataSequence, ISequence } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 
 export class Marker extends VectorSequence implements ISequence, IDataSequence {
+	readonly typeName = 'Marker';
 
 	/**
 	 * Creates a new Marker from the specified values.
@@ -31,5 +32,10 @@ export class Marker extends VectorSequence implements ISequence, IDataSequence {
 	 */
 	static fromArray(name: string, [x, y, z]: TypedArray[]) {
 		return new Marker(name, x, y, z);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isMarker(object: any): object is Marker {
+		return object?.typeName === 'Marker';
 	}
 }

--- a/src/lib/models/segment.ts
+++ b/src/lib/models/segment.ts
@@ -19,6 +19,8 @@ export type Kinematics = {
 }
 
 export class Segment implements ISequence, IDataSequence {
+	readonly typeName = 'Segment';
+
 	array: TypedArray[];
 	centerOfMass: Vector;
 	components = ['x', 'y', 'z', 'rx', 'ry', 'rz', 'rw'];
@@ -123,5 +125,10 @@ export class Segment implements ISequence, IDataSequence {
 			new QuaternionSequence(rx, ry, rz, rw),
 			undefined
 		);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isSegment(object: any): object is Segment {
+		return object?.typeName === 'Segment';
 	}
 }

--- a/src/lib/models/sequence/plane-sequence.ts
+++ b/src/lib/models/sequence/plane-sequence.ts
@@ -5,6 +5,7 @@ import { ISequence } from './sequence';
 import { VectorSequence } from './vector-sequence';
 
 export class PlaneSequence implements ISequence {
+	readonly typeName = 'PlaneSequence';
 	
 	array: TypedArray[];
 	components = ['a', 'b', 'c', 'd'];
@@ -155,6 +156,11 @@ export class PlaneSequence implements ISequence {
 		}
 
 		return new VectorSequence(x, y, z);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isPlaneSequence(object: any): object is PlaneSequence {
+		return object?.typeName === 'PlaneSequence';
 	}
 
 }

--- a/src/lib/models/sequence/quaternion-sequence.ts
+++ b/src/lib/models/sequence/quaternion-sequence.ts
@@ -4,6 +4,8 @@ import { Vector } from '../spatial/vector';
 import { ISequence } from './sequence';
 
 export class QuaternionSequence implements ISequence {
+	readonly typeName = 'QuaternionSequence';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'w'];
 
@@ -238,5 +240,10 @@ export class QuaternionSequence implements ISequence {
 		}
 
 		return result ? result : new QuaternionSequence(x, y, z, w);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isQuaternionSequence(object: any): object is QuaternionSequence {
+		return object?.typeName === 'QuaternionSequence';
 	}
 }

--- a/src/lib/models/sequence/sequence.ts
+++ b/src/lib/models/sequence/sequence.ts
@@ -1,5 +1,7 @@
 
 export interface ISequence {
+	typeName: string;
+
 	/** The sequence components as an array. */
 	array: TypedArray[];
 	/** The sequence length */

--- a/src/lib/models/sequence/vector-sequence.ts
+++ b/src/lib/models/sequence/vector-sequence.ts
@@ -4,6 +4,8 @@ import { Vector } from '../spatial/vector';
 import { ISequence } from './sequence';
 
 export class VectorSequence implements ISequence {
+	typeName = 'VectorSequence';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z'];
 
@@ -377,5 +379,10 @@ export class VectorSequence implements ISequence {
 		}
 
 		return result ? result : new VectorSequence(x, y, z, this.frameRate);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isVectorSequence(object: any): object is VectorSequence {
+		return object?.typeName === 'VectorSequence';
 	}
 }

--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -395,15 +395,15 @@ export class Signal implements IDataSequence {
 				this._type = SignalType.Float32Array;
 			}
 		}
-		else if (value instanceof Joint) {
+		else if (value instanceof Joint || Joint.isJoint(value)) {
 			this._value.joint = value;
 			this._type = SignalType.Joint;
 		}
-		else if (value instanceof ForcePlate) {
+		else if (value instanceof ForcePlate || ForcePlate.isForcePlate(value)) {
 			this._value.forcePlate = value;
 			this._type = SignalType.ForcePlate;
 		}
-		else if (value instanceof Segment) {
+		else if (value instanceof Segment || Segment.isSegment(value)) {
 			this._value.segment = value;
 			this._type = SignalType.Segment;
 		}
@@ -411,11 +411,11 @@ export class Signal implements IDataSequence {
 			this._value.string = value;
 			this._type = SignalType.String;
 		}
-		else if (value instanceof VectorSequence) {
+		else if (value instanceof VectorSequence || VectorSequence.isVectorSequence(value)) {
 			this._value.vectorSequence = value;
 			this._type = SignalType.VectorSequence;
 		}
-		else if (value instanceof PlaneSequence) {
+		else if (value instanceof PlaneSequence || PlaneSequence.isPlaneSequence(value)) {
 			this._value.planeSequence = value;
 			this._type = SignalType.PlaneSequence;
 		}
@@ -458,6 +458,7 @@ export class Signal implements IDataSequence {
 	getFloat32ArrayArrayValue(): Float32Array[] {
 		return this._value.numberArrayArray;
 	}
+
 	getJointValue(): Joint | null {
 		return this._value.joint;
 	}

--- a/src/lib/processing/arithmetic.ts
+++ b/src/lib/processing/arithmetic.ts
@@ -1,7 +1,6 @@
 import { Marker } from '../models/marker';
 import { PropertyType } from '../models/property';
 import { Segment } from '../models/segment';
-import { ISequence } from '../models/sequence/sequence';
 import { Signal, SignalType } from '../models/signal';
 import { StepCategory, StepClass } from '../step-registry';
 import { Arithmetic, ArithmeticOp } from '../utils/math/arithmetic';
@@ -171,7 +170,7 @@ export class BaseArithmeticStep extends BaseStep {
 			}
 		}
 
-		const operands = inputs.map(input => (input as ISequence).array.filter(x => x !== undefined)).filter(a => !!a).map(a => a.length === 1 ? a[0] : a);
+		const operands = inputs.map(input => input.array.filter(x => x !== undefined)).filter(a => !!a).map(a => a.length === 1 ? a[0] : a);
 
 		if (!operands.length) throw new ProcessingError('No operands given.');
 

--- a/src/lib/processing/concatenate.spec.ts
+++ b/src/lib/processing/concatenate.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 
+import { ArrayTestUtil } from '../../test-utils/array-utils';
 import { f32, i32, mockStep } from '../../test-utils/mock-step';
 import { Segment } from '../models/segment';
 import { QuaternionSequence } from '../models/sequence/quaternion-sequence';
@@ -132,6 +133,80 @@ test('ConcatenateStep - Multi-components (Segment)', async(t) => {
 	for (let i = 0; i < res.components.length; i++) {
 		if (i < 7) {
 			t.deepEqual(Array.from(res.getComponent(res.components[i])), [1, 2, 3, 4]);
+		}
+		else {
+			t.deepEqual(Array.from(res.getComponent(res.components[i])), [NaN, NaN, NaN, NaN]);
+		}
+	}
+});
+
+test('ConcatenateStep - 1D array (sort asc) A', async(t) => {
+	const step = mockStep(ConcatenateStep, [s1, s2], { sort: 'asc' });
+	const res = await step.process();
+	t.deepEqual(res.getValue(), f32(1, 2, 3, 4, 5, 6));
+});
+
+test('ConcatenateStep - 1D array (sort asc) B', async(t) => {
+	const step = mockStep(ConcatenateStep, [s2, s1], { sort: 'asc' });
+	const res = await step.process();
+	t.deepEqual(res.getValue(), f32(1, 2, 3, 4, 5, 6));
+});
+
+test('ConcatenateStep - 1D array (sort asc) C', async(t) => {
+	const shuffled1 = new Signal(ArrayTestUtil.shuffle(f32(1, 2, 3)));
+	const shuffled2 = new Signal(ArrayTestUtil.shuffle(f32(4, 5, 6)));
+	
+	const step = mockStep(ConcatenateStep, [shuffled1, shuffled2], { sort: 'asc' });
+	const res = await step.process();
+	t.deepEqual(res.getValue(), f32(1, 2, 3, 4, 5, 6));
+});
+
+test('ConcatenateStep - 1D array (sort desc) A', async(t) => {
+	const step = mockStep(ConcatenateStep, [s1, s2], { sort: 'desc' });
+	const res = await step.process();
+	t.deepEqual(res.getValue(), f32(6, 5, 4, 3, 2, 1));
+});
+
+test('ConcatenateStep - 1D array (sort desc) B', async(t) => {
+	const step = mockStep(ConcatenateStep, [s2, s1], { sort: 'desc' });
+	const res = await step.process();
+	t.deepEqual(res.getValue(), f32(6, 5, 4, 3, 2, 1));
+});
+
+test('ConcatenateStep - 1D array (sort desc) C', async(t) => {
+	const shuffled1 = new Signal(ArrayTestUtil.shuffle(f32(1, 2, 3)));
+	const shuffled2 = new Signal(ArrayTestUtil.shuffle(f32(4, 5, 6)));
+	
+	const step = mockStep(ConcatenateStep, [shuffled1, shuffled2], { sort: 'desc' });
+	const res = await step.process();
+	t.deepEqual(res.getValue(), f32(6, 5, 4, 3, 2, 1));
+});
+
+test('ConcatenateStep - Multi-components (Segment) (sort asc)', async(t) => {
+	const step = mockStep(ConcatenateStep, [segment2, segment1], { sort: 'asc' });
+	const res = await step.process();
+
+	t.deepEqual(res.components, segment1.components);
+
+	for (let i = 0; i < res.components.length; i++) {
+		if (i < 7) {
+			t.deepEqual(Array.from(res.getComponent(res.components[i])), [1, 2, 3, 4]);
+		}
+		else {
+			t.deepEqual(Array.from(res.getComponent(res.components[i])), [NaN, NaN, NaN, NaN]);
+		}
+	}
+});
+
+test('ConcatenateStep - Multi-components (Segment) (sort desc)', async(t) => {
+	const step = mockStep(ConcatenateStep, [segment2, segment1], { sort: 'desc' });
+	const res = await step.process();
+
+	t.deepEqual(res.components, segment1.components);
+
+	for (let i = 0; i < res.components.length; i++) {
+		if (i < 7) {
+			t.deepEqual(Array.from(res.getComponent(res.components[i])), [4, 3, 2, 1]);
 		}
 		else {
 			t.deepEqual(Array.from(res.getComponent(res.components[i])), [NaN, NaN, NaN, NaN]);

--- a/src/lib/processing/events/event-duration.spec.ts
+++ b/src/lib/processing/events/event-duration.spec.ts
@@ -20,8 +20,6 @@ const e1Shuffle = new Signal(eventFrames1Shuffle, frameRate);
 const e2Shuffle = new Signal(eventFrames2Shuffle, frameRate);
 const ef1 = new Signal(eventFrames1); // No frame rate
 const ef2 = new Signal(eventFrames1); // No frame rate
-const ef1Shuffle = new Signal(eventFrames1Shuffle); // No frame rate
-const ef2Shuffle = new Signal(eventFrames2Shuffle); // No frame rate
 
 const s1 = new Signal(new VectorSequence(eventFrames1, eventFrames1, eventFrames1)); // Wrong type
 const s2 = new Signal(0.1); // Wrong type

--- a/src/lib/processing/events/event-duration.spec.ts
+++ b/src/lib/processing/events/event-duration.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 
+import { ArrayTestUtil } from '../../../test-utils/array-utils';
 import { f32, i32, mockStep } from '../../../test-utils/mock-step';
 import { VectorSequence } from '../../models/sequence/vector-sequence';
 import { Signal } from '../../models/signal';
@@ -10,10 +11,18 @@ const eventFrames1 = i32(1, 10, 100);
 const eventFrames2 = i32(5, 50, 150);
 const frameRate = 300;
 
+const eventFrames1Shuffle = ArrayTestUtil.shuffle(eventFrames1);
+const eventFrames2Shuffle = ArrayTestUtil.shuffle(eventFrames2);
+
 const e1 = new Signal(eventFrames1, frameRate);
 const e2 = new Signal(eventFrames2, frameRate);
+const e1Shuffle = new Signal(eventFrames1Shuffle, frameRate);
+const e2Shuffle = new Signal(eventFrames2Shuffle, frameRate);
 const ef1 = new Signal(eventFrames1); // No frame rate
 const ef2 = new Signal(eventFrames1); // No frame rate
+const ef1Shuffle = new Signal(eventFrames1Shuffle); // No frame rate
+const ef2Shuffle = new Signal(eventFrames2Shuffle); // No frame rate
+
 const s1 = new Signal(new VectorSequence(eventFrames1, eventFrames1, eventFrames1)); // Wrong type
 const s2 = new Signal(0.1); // Wrong type
 
@@ -30,6 +39,12 @@ test('EventDurationStep', async(t) => {
 	const res = await step.process();
 
 	t.deepEqual(res.getValue(), f32(...eventFrames1).map((f, i) => (eventFrames2[i] - f) / frameRate));
+
+	// Test random shuffle.
+	const stepShuffle = mockStep(EventDurationStep, [e1Shuffle, e2Shuffle]);
+	const resShuffle = await stepShuffle.process();
+
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('EventDurationStep - exclude single', async(t) => {
@@ -41,6 +56,16 @@ test('EventDurationStep - exclude single', async(t) => {
 	const res = await step.process();
 
 	t.deepEqual(res.getValue(), f32(0.09, 0.14, 0.24));
+
+	// Test random shuffle.
+	const framesAShuffle = new Signal(ArrayTestUtil.shuffle(framesA.getUint32ArrayValue()), 100);
+	const framesBShuffle = new Signal(ArrayTestUtil.shuffle(framesB.getUint32ArrayValue()), 100);
+	const excludeShuffle = new Signal(ArrayTestUtil.shuffle(exclude.getUint32ArrayValue()), 100);
+
+	const stepShuffle = mockStep(EventDurationStep, [framesAShuffle, framesBShuffle], { exclude: [excludeShuffle] });
+	const resShuffle = await stepShuffle.process();
+
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('EventDurationStep - exclude multiple', async(t) => {
@@ -53,6 +78,17 @@ test('EventDurationStep - exclude multiple', async(t) => {
 	const res = await step.process();
 
 	t.deepEqual(res.getValue(), f32(0.14, 0.24));
+
+	// Test random shuffle.
+	const framesAShuffle = new Signal(ArrayTestUtil.shuffle(framesA.getUint32ArrayValue()), 100);
+	const framesBShuffle = new Signal(ArrayTestUtil.shuffle(framesB.getUint32ArrayValue()), 100);
+	const excludeAShuffle = new Signal(ArrayTestUtil.shuffle(excludeA.getUint32ArrayValue()), 100);
+	const excludeBShuffle = new Signal(ArrayTestUtil.shuffle(excludeB.getUint32ArrayValue()), 100);
+
+	const stepShuffle = mockStep(EventDurationStep, [framesAShuffle, framesBShuffle], { exclude: [excludeAShuffle, excludeBShuffle] });
+	const resShuffle = await stepShuffle.process();
+
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('EventDurationStep - include single', async(t) => {
@@ -64,6 +100,16 @@ test('EventDurationStep - include single', async(t) => {
 	const res = await step.process();
 
 	t.deepEqual(res.getValue(), f32(0.09, 0.14, 0.24));
+
+	// Test random shuffle.
+	const framesAShuffle = new Signal(ArrayTestUtil.shuffle(framesA.getUint32ArrayValue()), 100);
+	const framesBShuffle = new Signal(ArrayTestUtil.shuffle(framesB.getUint32ArrayValue()), 100);
+	const includeShuffle = new Signal(ArrayTestUtil.shuffle(include.getUint32ArrayValue()), 100);
+
+	const stepShuffle = mockStep(EventDurationStep, [framesAShuffle, framesBShuffle], { include: [includeShuffle] });
+	const resShuffle = await stepShuffle.process();
+
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('EventDurationStep - include multiple', async(t) => {
@@ -76,6 +122,17 @@ test('EventDurationStep - include multiple', async(t) => {
 	const res = await step.process();
 
 	t.deepEqual(res.getValue(), f32(0.14, 0.24));
+
+	// Test random shuffle.
+	const framesAShuffle = new Signal(ArrayTestUtil.shuffle(framesA.getUint32ArrayValue()), 100);
+	const framesBShuffle = new Signal(ArrayTestUtil.shuffle(framesB.getUint32ArrayValue()), 100);
+	const includeAShuffle = new Signal(ArrayTestUtil.shuffle(includeA.getUint32ArrayValue()), 100);
+	const includeBShuffle = new Signal(ArrayTestUtil.shuffle(includeB.getUint32ArrayValue()), 100);
+
+	const stepShuffle = mockStep(EventDurationStep, [framesAShuffle, framesBShuffle], { include: [includeAShuffle, includeBShuffle] });
+	const resShuffle = await stepShuffle.process();
+
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('EventMaskStep - include and exclude', async(t) => {
@@ -85,10 +142,20 @@ test('EventMaskStep - include and exclude', async(t) => {
 	const include = new Signal(i32(12, 24, 62), 100);
 
 	const step = mockStep(EventDurationStep, [framesA, framesB], { exclude: [exclude], include: [include] });
-
 	const res = await step.process();
 
 	t.deepEqual(res.getValue(), f32(0.09, 0.24));
+
+	// Test random shuffle.
+	const framesAShuffle = new Signal(ArrayTestUtil.shuffle(framesA.getUint32ArrayValue()), 100);
+	const framesBShuffle = new Signal(ArrayTestUtil.shuffle(framesB.getUint32ArrayValue()), 100);
+	const excludeShuffle = new Signal(ArrayTestUtil.shuffle(exclude.getUint32ArrayValue()), 100);
+	const includeShuffle = new Signal(ArrayTestUtil.shuffle(include.getUint32ArrayValue()), 100);
+
+	const stepShuffle = mockStep(EventDurationStep, [framesAShuffle, framesBShuffle], { exclude: [excludeShuffle], include: [includeShuffle] });
+	const resShuffle = await stepShuffle.process();
+
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('EventMaskStep - incompatible include', async(t) => {

--- a/src/lib/processing/events/event-mask.ts
+++ b/src/lib/processing/events/event-mask.ts
@@ -219,7 +219,10 @@ export class EventMaskStep extends BaseStep {
 		 * within the span of one of the event pairs will be returned.
 		 */
 		if (source.isEvent) {
-			const sourceFrames = (source.type === SignalType.Float32Array) ? source.getFloat32ArrayValue() : source.getUint32ArrayValue();
+			const sourceFrames = ((source.type === SignalType.Float32Array) ? source.getFloat32ArrayValue() : source.getUint32ArrayValue())
+				.slice()
+				.sort((a, b) => a - b) // Sort the frames to ensure that the pairs are in order.
+			;
 			let filteredFrames;
 
 			if (!this.keep) {

--- a/src/lib/processing/events/refine-event.spec.ts
+++ b/src/lib/processing/events/refine-event.spec.ts
@@ -20,9 +20,6 @@ const framesX1Shuffle = ArrayTestUtil.shuffle(framesX1);
 const vs = new VectorSequence(framesA, framesA, framesA);
 const sVS = new Signal(vs);
 
-const vsShuffle = new VectorSequence(framesAShuffle, framesAShuffle, framesAShuffle);
-const sVSShuffle = new Signal(vsShuffle);
-
 const sA = new Signal(framesA);
 const sB = new Signal(framesB);
 const sC = new Signal(framesC);

--- a/src/lib/processing/events/refine-event.spec.ts
+++ b/src/lib/processing/events/refine-event.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 
+import { ArrayTestUtil } from '../../../test-utils/array-utils';
 import { f32, mockStep } from '../../../test-utils/mock-step';
 import { VectorSequence } from '../../models/sequence/vector-sequence';
 import { Signal } from '../../models/signal';
@@ -11,13 +12,26 @@ const framesB = f32(2, 6, 11, 16);
 const framesC = f32(3, 7, 12, 17, 22);
 const framesX1 = f32(1.5, 16.5);
 
+const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+const framesCShuffle = ArrayTestUtil.shuffle(framesC);
+const framesX1Shuffle = ArrayTestUtil.shuffle(framesX1);
+
 const vs = new VectorSequence(framesA, framesA, framesA);
 const sVS = new Signal(vs);
+
+const vsShuffle = new VectorSequence(framesAShuffle, framesAShuffle, framesAShuffle);
+const sVSShuffle = new Signal(vsShuffle);
 
 const sA = new Signal(framesA);
 const sB = new Signal(framesB);
 const sC = new Signal(framesC);
 const sX = new Signal(framesX1);
+
+const sAShuffle = new Signal(framesAShuffle);
+const sBShuffle = new Signal(framesBShuffle);
+const sCShuffle = new Signal(framesCShuffle);
+const sXShuffle = new Signal(framesX1Shuffle);
 
 /** 
  * The following tests verify the *input handling*. The pattern handling is
@@ -51,26 +65,38 @@ test('RefineEventStep - Options - sequence, exclude & cyclic', async t => {
 
 test('RefineEventStep - Result - sequence only', async t => {
 	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC] }).process();
-
 	t.deepEqual(res.getValue(), f32(1, 5, 10, 15));
+
+	// Test random shuffle.
+	const resShuffle = await mockStep(RefineEventStep, [sAShuffle], { sequence: [sAShuffle, sBShuffle, sCShuffle] }).process();
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('RefineEventStep - Result - sequence & exclude', async t => {
 	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC], exclude: [sX] }).process();
-
 	t.deepEqual(res.getValue(), f32(5, 10));
+
+	// Test random shuffle.
+	const resShuffle = await mockStep(RefineEventStep, [sAShuffle], { sequence: [sAShuffle, sBShuffle, sCShuffle], exclude: [sXShuffle] }).process();
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('RefineEventStep - Result - cyclic true', async t => {
 	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC, sA], exclude: [sX], cyclic: true }).process();
-
 	t.deepEqual(res.getValue(), f32(5, 10, 15));
+
+	// Test random shuffle.
+	const resShuffle = await mockStep(RefineEventStep, [sAShuffle], { sequence: [sAShuffle, sBShuffle, sCShuffle, sAShuffle], exclude: [sXShuffle], cyclic: true }).process();
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('RefineEventStep - Result - cyclic false', async t => {
 	const res = await mockStep(RefineEventStep, [sA], { sequence: [sA, sB, sC, sA], exclude: [sX], cyclic: false }).process();
-
 	t.deepEqual(res.getValue(), f32(5, 10));
+
+	// Test random shuffle.
+	const resShuffle = await mockStep(RefineEventStep, [sAShuffle], { sequence: [sAShuffle, sBShuffle, sCShuffle, sAShuffle], exclude: [sXShuffle], cyclic: false }).process();
+	t.deepEqual(resShuffle.getValue(), res.getValue());
 });
 
 test('RefineEventStep - makeArray', async t => {

--- a/src/lib/utils/events.spec.ts
+++ b/src/lib/utils/events.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 
+import { ArrayTestUtil } from '../../test-utils/array-utils';
 import { f32 } from '../../test-utils/mock-step';
 
 import { EventUtil } from './events';
@@ -16,6 +17,15 @@ test('EventUtil - eventSequence', (t) => {
 		{ start: 10, end: 12 },
 	]);
 
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle);
+
+	t.deepEqual(spansShuffle, spans);
+
+	// Test empty input
 	const spans2 = EventUtil.eventSequence(framesA, []);
 
 	t.deepEqual(spans2, []);
@@ -33,6 +43,15 @@ test('EventUtil - eventSequence - exclude single', (t) => {
 		{ start: 10, end: 14 },
 		{ start: 20, end: 24 },
 	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+	const excludeShuffle = ArrayTestUtil.shuffle(exclude);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle, [excludeShuffle]);
+
+	t.deepEqual(spansShuffle, spans);
 });
 
 test('EventUtil - eventSequence - exclude multiple', (t) => {
@@ -47,6 +66,17 @@ test('EventUtil - eventSequence - exclude multiple', (t) => {
 	t.deepEqual(spans, [
 		{ start: 10, end: 14 },
 	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+	const excludeAShuffle = ArrayTestUtil.shuffle(excludeA);
+	const excludeBShuffle = ArrayTestUtil.shuffle(excludeB);
+	const excludeCShuffle = ArrayTestUtil.shuffle(excludeC);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle, [excludeAShuffle, excludeBShuffle, excludeCShuffle]);
+
+	t.deepEqual(spansShuffle, spans);
 });
 
 test('EventUtil - eventSequence - include single', (t) => {
@@ -60,6 +90,15 @@ test('EventUtil - eventSequence - include single', (t) => {
 		{ start: 1, end: 4 },
 		{ start: 15, end: 19 },
 	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+	const includeShuffle = ArrayTestUtil.shuffle(include);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle, undefined, [includeShuffle]);
+
+	t.deepEqual(spansShuffle, spans);
 });
 
 test('EventUtil - eventSequence - include multiple', (t) => {
@@ -74,6 +113,17 @@ test('EventUtil - eventSequence - include multiple', (t) => {
 	t.deepEqual(spans, [
 		{ start: 15, end: 19 },
 	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+	const includeAShuffle = ArrayTestUtil.shuffle(includeA);
+	const includeBShuffle = ArrayTestUtil.shuffle(includeB);
+	const includeCShuffle = ArrayTestUtil.shuffle(includeC);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle, undefined, [includeAShuffle, includeBShuffle, includeCShuffle]);
+
+	t.deepEqual(spansShuffle, spans);
 });
 
 test('EventUtil - eventSequence - include and exclude - single', (t) => {
@@ -88,6 +138,16 @@ test('EventUtil - eventSequence - include and exclude - single', (t) => {
 		{ start: 5, end: 9 },
 		{ start: 10, end: 14 },
 	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+	const excludeShuffle = ArrayTestUtil.shuffle(exclude);
+	const includeShuffle = ArrayTestUtil.shuffle(include);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle, [excludeShuffle], [includeShuffle]);
+
+	t.deepEqual(spansShuffle, spans);
 });
 
 test('EventUtil - eventSequence - include and exclude - multiple', (t) => {
@@ -103,6 +163,18 @@ test('EventUtil - eventSequence - include and exclude - multiple', (t) => {
 	t.deepEqual(spans, [
 		{ start: 5, end: 9 },
 	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+	const excludeAShuffle = ArrayTestUtil.shuffle(excludeA);
+	const excludeBShuffle = ArrayTestUtil.shuffle(excludeB);
+	const includeAShuffle = ArrayTestUtil.shuffle(includeA);
+	const includeBShuffle = ArrayTestUtil.shuffle(includeB);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle, [excludeAShuffle, excludeBShuffle], [includeAShuffle, includeBShuffle]);
+
+	t.deepEqual(spansShuffle, spans);
 });
 
 
@@ -146,6 +218,46 @@ test('EventUtil - pickFromSequence', (t) => {
 	t.deepEqual(evt9, f32(6, 11));
 });
 
+test('EventUtil - pickFromSequence (shuffled order)', (t) => {
+	const framesA  = ArrayTestUtil.shuffle(f32(1, 5, 10, 15, 20));
+	const framesB1 = ArrayTestUtil.shuffle(f32(2, 6, 11, 16));
+	const framesB2 = ArrayTestUtil.shuffle(f32(2, 6,     16));
+	const framesC  = ArrayTestUtil.shuffle(f32(3, 7, 12, 17, 22));
+
+	const framesX1 = ArrayTestUtil.shuffle(f32(1.5, 16.5));
+	const framesX2 = ArrayTestUtil.shuffle(f32(6.5));
+
+	const evt1 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC]);
+	t.deepEqual(evt1, f32(1, 5, 10, 15));
+
+	const evt2 = EventUtil.pickFromSequence(framesA, [framesA, framesB2, framesC]);
+	t.deepEqual(evt2, f32(1, 5, 15));
+
+	const evt3 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC], [framesX1]);
+	t.deepEqual(evt3, f32(5, 10));
+
+	const evt4 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC], [framesX2]);
+	t.deepEqual(evt4, f32(1, 10, 15));
+
+	const evt5 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC], [framesX1, framesX2]);
+	t.deepEqual(evt5, f32(10));
+
+	// The "pick" is not in the sequence
+	const evt6 = EventUtil.pickFromSequence(framesA, [f32(1, 5, 10, 15), framesB1, framesC]);
+	t.deepEqual(evt6, f32());
+
+	// No sequence provided
+	const evt7 = EventUtil.pickFromSequence(framesA, []);
+	t.deepEqual(evt7, f32());
+
+	// The "pick" appears multiple times in the sequence
+	const evt8 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA]);
+	t.deepEqual(evt8, f32(1, 5, 10, 15));
+
+	const evt9 = EventUtil.pickFromSequence(framesB1, [framesA, framesB1, framesC, framesA, framesB1], [framesX1]);
+	t.deepEqual(evt9, f32(6, 11));
+});
+
 test('EventUtil - pickFromSequence (cyclic)', (t) => {
 	const framesA  = f32(1, 5, 10, 15, 20);
 	const framesB1 = f32(2, 6, 11, 16);
@@ -154,6 +266,34 @@ test('EventUtil - pickFromSequence (cyclic)', (t) => {
 
 	const framesX1 = f32(1.5, 16.5);
 	const framesX2 = f32(6.5);
+
+	const evt1 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], undefined, true);
+	t.deepEqual(evt1, f32(1, 5, 10, 15, 20));
+
+	const evt2 = EventUtil.pickFromSequence(framesA, [framesA, framesB2, framesC, framesA], undefined, true);
+	t.deepEqual(evt2, f32(1, 5, 10, 15, 20));
+
+	const evt3 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], [framesX1], true);
+	t.deepEqual(evt3, f32(5, 10, 15));
+
+	const evt4 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], [framesX2], true);
+	t.deepEqual(evt4, f32(1, 5, 10, 15, 20));
+
+	const evt5 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], [framesX1, framesX2]);
+	t.deepEqual(evt5, f32(10, 15));
+
+	const evt9 = EventUtil.pickFromSequence(framesB1, [framesA, framesB1, framesC, framesA, framesB1], [framesX1], true);
+	t.deepEqual(evt9, f32(6, 11, 16));
+});
+
+test('EventUtil - pickFromSequence (cyclic, shuffled order)', (t) => {
+	const framesA  = ArrayTestUtil.shuffle(f32(1, 5, 10, 15, 20));
+	const framesB1 = ArrayTestUtil.shuffle(f32(2, 6, 11, 16));
+	const framesB2 = ArrayTestUtil.shuffle(f32(2, 6,     16));
+	const framesC  = ArrayTestUtil.shuffle(f32(3, 7, 12, 17, 22));
+
+	const framesX1 = ArrayTestUtil.shuffle(f32(1.5, 16.5));
+	const framesX2 = ArrayTestUtil.shuffle(f32(6.5));
 
 	const evt1 = EventUtil.pickFromSequence(framesA, [framesA, framesB1, framesC, framesA], undefined, true);
 	t.deepEqual(evt1, f32(1, 5, 10, 15, 20));

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -31,8 +31,16 @@ export class EventUtil {
 	 * @param excludeFrames Frames which invalidates the sequence. Any sequence containing any of these frames will be excluded.
 	 * @param includeFrames Frames which must be present in the sequence. Only sequences that contain at least one frame from each of the frame arrays will be returned.
 	 */
-	static eventSequence(fromFrames: NumericArray, toFrames: NumericArray, excludeFrames: NumericArray[] = undefined, includeFrames: NumericArray[] = undefined): IFrameSpan[] {
+	static eventSequence(fromFramesSrc: NumericArray, toFramesSrc: NumericArray, excludeFramesSrc: NumericArray[] = undefined, includeFramesSrc: NumericArray[] = undefined): IFrameSpan[] {
 		// TODO: Use logic from web report
+
+		// Copy arrays to avoid mutation, then sort them.
+		const sortFn = (a: number, b: number) => a - b;
+
+		const fromFrames = fromFramesSrc?.slice().sort(sortFn);
+		const toFrames = toFramesSrc?.slice().sort(sortFn);
+		const excludeFrames = excludeFramesSrc ? excludeFramesSrc.map(f => f.slice().sort(sortFn)) : undefined;
+		const includeFrames = includeFramesSrc ? includeFramesSrc.map(f => f.slice().sort(sortFn)) : undefined;
 
 		// Generate event frame pairs
 		const pairs: IFrameSpan[] = [];

--- a/src/test-utils/array-utils.spec.ts
+++ b/src/test-utils/array-utils.spec.ts
@@ -1,0 +1,63 @@
+import test from 'ava';
+
+import { ArrayTestUtil } from './array-utils';
+import { f32 } from './mock-step';
+
+test('ArrayUtil.shuffle - input errors', async(t) => {
+	t.throws(() => ArrayTestUtil.shuffle(undefined));
+	t.throws(() => ArrayTestUtil.shuffle(null));
+});
+
+test('ArrayUtil.shuffle - empty input', async(t) => {
+	const empty1 = [];
+	t.deepEqual(ArrayTestUtil.shuffle(empty1), empty1);
+	t.not(ArrayTestUtil.shuffle(empty1), empty1);
+
+	const empty2 = f32();
+	t.deepEqual(ArrayTestUtil.shuffle<Float32Array>(empty2), empty2);
+	t.not(ArrayTestUtil.shuffle(empty2), empty2);
+
+});
+
+test('ArrayUtil.shuffle - single length input', async(t) => {
+	const single1 = [1];
+	t.deepEqual(ArrayTestUtil.shuffle(single1), single1);
+	t.not(ArrayTestUtil.shuffle(single1), single1);
+
+	const single2 = f32(1);
+	t.deepEqual(ArrayTestUtil.shuffle(single2), single2);
+	t.not(ArrayTestUtil.shuffle(single2), single2);
+});
+
+test('ArrayUtil.shuffle - multi length input', async(t) => {
+	const multi1 = [1, 2, 3, 4, 5];
+	t.notDeepEqual(ArrayTestUtil.shuffle(multi1), multi1);
+	t.not(ArrayTestUtil.shuffle(multi1), multi1);
+
+	const multi2 = f32(1, 2, 3, 4, 5);
+	t.notDeepEqual(ArrayTestUtil.shuffle(multi2), multi2);
+	t.not(ArrayTestUtil.shuffle(multi2), multi2);
+});
+
+test('ArrayUtil.shuffle - length 2', async(t) => {
+	// Arrays should always be different, if there are only 2 elements
+	// there is only one possible shuffle.
+	const multi1 = [1, 2];
+	t.deepEqual(ArrayTestUtil.shuffle(multi1), [2, 1]);
+	t.not(ArrayTestUtil.shuffle(multi1), multi1);
+
+	const multi2 = f32(1, 2);
+	t.deepEqual(ArrayTestUtil.shuffle(multi2), f32(2, 1));
+	t.not(ArrayTestUtil.shuffle(multi2), multi2);
+});
+
+test('ArrayUtil.shuffle - same values', async(t) => {
+	// If all values are the same, the array will look the same.
+	const multi1 = [5, 5, 5, 5, 5];
+	t.deepEqual(ArrayTestUtil.shuffle(multi1), multi1);
+	t.not(ArrayTestUtil.shuffle(multi1), multi1);
+
+	const multi2 = f32(5, 5, 5, 5, 5);
+	t.deepEqual(ArrayTestUtil.shuffle(multi2), multi2);
+	t.not(ArrayTestUtil.shuffle(multi2), multi2);
+});

--- a/src/test-utils/array-utils.ts
+++ b/src/test-utils/array-utils.ts
@@ -1,0 +1,33 @@
+import { TypeCheck } from '../lib/utils/type-check';
+
+export class ArrayTestUtil {
+	/**
+	 * Shuffles the array and returns a new array.
+	 * 
+	 * The resulting array is guaranteed to be different from the input array,
+	 * unless the input array is empty, has only one element, or all elements are the same.
+	 * 
+	 * @param array The array to shuffle.
+	 * @returns A new array with the same elements, but shuffled.
+	 * @throws If the input is undefined.
+	 * @throws If the input is not array-like.
+	 */
+	static shuffle<T extends NumericArray>(array: T): T {
+		if (!array) throw new Error('Array is undefined');
+		if (!TypeCheck.isArrayLike(array)) throw new Error('Input is not array-like');
+		
+		const copy = array.slice() as T;
+		
+		if (!array.length || array.length === 1) return copy;
+
+		for (let i = copy.length - 1; i > 0; i--) {
+			const j = Math.floor(Math.random() * (i + 1));
+			[copy[i], copy[j]] = [copy[j], copy[i]];
+		}
+
+		// Check if the array is still the same, if so, reverse it.
+		if (array.every((v, i) => v === copy[i])) return copy.reverse() as T;
+
+		return copy;
+	}
+}


### PR DESCRIPTION
This PR addresses an issue where event utility steps were assuming event frames to be in order. After the fix, the order of the event frames does not matter when running steps such as `eventDuration`, `eventMask`, or `refineEvent`.

Additionally, the `concatenate` step now has a `sort` option to sort the resulting values. From the docs:

>
> #### `sort`
>
> **Type:** `String`  
> **Required:** `False`  
> **Allowed values:** `asc | desc`  
> **Default value:** `null`  
>
> If defined, the resulting array(s) will be sorted by value in ascending 
> or descending order.
>


### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [N/A] Documentation added

Work item: [AB#36247](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/36247)