### PR TITLE
Fix ensureContinuity for quaternions 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calqulus-steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calqulus-steps",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/parser": "^5.27.0",
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001564",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-      "integrity": "sha1-6qi7xYwMvM3Le0EYbfOd0rpZGIk=",
+      "version": "1.0.30001621",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
+      "integrity": "sha1-Sty0Q8i5yDA+BEmDGPmHYWuP6i4=",
       "dev": true,
       "funding": [
         {
@@ -10134,9 +10134,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001564",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-      "integrity": "sha1-6qi7xYwMvM3Le0EYbfOd0rpZGIk=",
+      "version": "1.0.30001621",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
+      "integrity": "sha1-Sty0Q8i5yDA+BEmDGPmHYWuP6i4=",
       "dev": true
     },
     "cbor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calqulus-steps",
-  "version": "1.3.1",
+  "version": "1.3.1-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calqulus-steps",
-      "version": "1.3.1",
+      "version": "1.3.1-beta.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/parser": "^5.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calqulus-steps",
-  "version": "1.3.1",
+  "version": "1.3.1-beta.2",
   "description": "Processing steps for Calqulus - Qualisys online processing engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calqulus-steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Processing steps for Calqulus - Qualisys online processing engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/regression-test-versions.json
+++ b/regression-test-versions.json
@@ -1,15 +1,15 @@
 {
 	"ci": "main",
 	"current": {
-		"engine": "feature/force-plate",
-		"pipelines": "0f4a6684dafcb9a5ee9ab0eedb1932b2b34c606f",
-		"toolbelt": "feature/inverse-dynamics"
+		"engine": "main",
+		"pipelines": "08d038b2b97039287a902f464ef3ae21f3a07eaf",
+		"toolbelt": "main"
 	},
 	"reference": {
-		"engine": "a348dda6e2d87de93faeda5f2111dcee8cb90e92",
-		"steps": "d1d2ce59c90e230d4d218db5b038967c1f03c2e9",
-		"pipelines": "0f4a6684dafcb9a5ee9ab0eedb1932b2b34c606f",
-		"toolbelt": "369b23c9eed2e7cc9055ee48e4d887b059609510"
+		"engine": "6f0b9af34ab8deb9b90f386c2a5ebba13088a89e",
+		"steps": "2c9e0a56d6b523aff3823ba927547967f0d2ad04",
+		"pipelines": "08d038b2b97039287a902f464ef3ae21f3a07eaf",
+		"toolbelt": "6b777faf563b4007c728ddaae1e844a0956c7e4e"
 	},
 	"lastSuccessful": {
 		"engine": "main",

--- a/src/lib/models/analog.ts
+++ b/src/lib/models/analog.ts
@@ -1,6 +1,8 @@
 import { IDataSequence, ISequence } from './sequence/sequence';
 
 export class Analog implements ISequence, IDataSequence {
+	readonly typeName = 'Analog';
+
 	array = [this.signal];
 	components = ['signal'];
 
@@ -19,5 +21,10 @@ export class Analog implements ISequence, IDataSequence {
 		const index = this.components.indexOf(component);
 
 		return this.array[index];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isAnalog(object: any): object is Analog {
+		return object?.typeName === 'Analog';
 	}
 }

--- a/src/lib/models/force-plate.ts
+++ b/src/lib/models/force-plate.ts
@@ -3,6 +3,8 @@ import { VectorSequence } from './sequence/vector-sequence';
 import { IVector } from './spatial/vector';
 
 export class ForcePlate implements ISequence, IDataSequence {
+	readonly typeName = 'ForcePlate';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'fx', 'fy', 'fz', 'mx', 'my', 'mz'];
 
@@ -108,5 +110,10 @@ export class ForcePlate implements ISequence, IDataSequence {
 		);
 
 		return fp;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isForcePlate(object: any): object is ForcePlate {
+		return object?.typeName === 'ForcePlate';
 	}
 }

--- a/src/lib/models/joint.ts
+++ b/src/lib/models/joint.ts
@@ -3,6 +3,8 @@ import { IDataSequence, ISequence } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 
 export class Joint implements ISequence, IDataSequence {
+	readonly typeName = 'Joint';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'fx', 'fy', 'fz', 'mx', 'my', 'mz', 'p'];
 	distalSegment: Segment;
@@ -92,5 +94,10 @@ export class Joint implements ISequence, IDataSequence {
 	 */
 	static fromArray(name: string, [x, y, z, fx, fy, fz, mx, my, mz, p]: TypedArray[]) {
 		return new Joint(name, new VectorSequence(x, y, z), new VectorSequence(fx, fy, fz), new VectorSequence(mx, my, mz), p as Float32Array);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isJoint(object: any): object is Joint {
+		return object?.typeName === 'Joint';
 	}
 }

--- a/src/lib/models/marker.ts
+++ b/src/lib/models/marker.ts
@@ -2,6 +2,7 @@ import { IDataSequence, ISequence } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 
 export class Marker extends VectorSequence implements ISequence, IDataSequence {
+	readonly typeName = 'Marker';
 
 	/**
 	 * Creates a new Marker from the specified values.
@@ -31,5 +32,10 @@ export class Marker extends VectorSequence implements ISequence, IDataSequence {
 	 */
 	static fromArray(name: string, [x, y, z]: TypedArray[]) {
 		return new Marker(name, x, y, z);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isMarker(object: any): object is Marker {
+		return object?.typeName === 'Marker';
 	}
 }

--- a/src/lib/models/segment.ts
+++ b/src/lib/models/segment.ts
@@ -19,6 +19,8 @@ export type Kinematics = {
 }
 
 export class Segment implements ISequence, IDataSequence {
+	readonly typeName = 'Segment';
+
 	array: TypedArray[];
 	centerOfMass: Vector;
 	components = ['x', 'y', 'z', 'rx', 'ry', 'rz', 'rw'];
@@ -123,5 +125,10 @@ export class Segment implements ISequence, IDataSequence {
 			new QuaternionSequence(rx, ry, rz, rw),
 			undefined
 		);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isSegment(object: any): object is Segment {
+		return object?.typeName === 'Segment';
 	}
 }

--- a/src/lib/models/sequence/plane-sequence.ts
+++ b/src/lib/models/sequence/plane-sequence.ts
@@ -5,6 +5,7 @@ import { ISequence } from './sequence';
 import { VectorSequence } from './vector-sequence';
 
 export class PlaneSequence implements ISequence {
+	readonly typeName = 'PlaneSequence';
 	
 	array: TypedArray[];
 	components = ['a', 'b', 'c', 'd'];
@@ -155,6 +156,11 @@ export class PlaneSequence implements ISequence {
 		}
 
 		return new VectorSequence(x, y, z);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isPlaneSequence(object: any): object is PlaneSequence {
+		return object?.typeName === 'PlaneSequence';
 	}
 
 }

--- a/src/lib/models/sequence/quaternion-sequence.ts
+++ b/src/lib/models/sequence/quaternion-sequence.ts
@@ -4,6 +4,8 @@ import { Vector } from '../spatial/vector';
 import { ISequence } from './sequence';
 
 export class QuaternionSequence implements ISequence {
+	readonly typeName = 'QuaternionSequence';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'w'];
 
@@ -238,5 +240,10 @@ export class QuaternionSequence implements ISequence {
 		}
 
 		return result ? result : new QuaternionSequence(x, y, z, w);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isQuaternionSequence(object: any): object is QuaternionSequence {
+		return object?.typeName === 'QuaternionSequence';
 	}
 }

--- a/src/lib/models/sequence/quaternion-sequence.ts
+++ b/src/lib/models/sequence/quaternion-sequence.ts
@@ -73,8 +73,8 @@ export class QuaternionSequence implements ISequence {
 			prev.w = w[i - 1];
 
 			// Method with geodesic distance
-			const prevInv = Quaternion.invert(prev, Quaternion.tmpQuat2);
-			const prevInvCur = prevInv.multiplyToRef(cur, Quaternion.tmpQuat1);
+			const prevInv = Quaternion.invert(prev, Quaternion.tmpQuat3);
+			const prevInvCur = prevInv.multiplyToRef(cur, Quaternion.tmpQuat4);
 			const theta = 2 * Math.atan2(Math.hypot(prevInvCur.x, prevInvCur.y, prevInvCur.z), prevInvCur.w);
 			const k = Vector.normalize(new Vector(prevInvCur.x, prevInvCur.y, prevInvCur.z), Vector.tmpVec1);
 			let halfKTheta = new Vector(0, 0, 0);

--- a/src/lib/models/sequence/sequence.ts
+++ b/src/lib/models/sequence/sequence.ts
@@ -1,5 +1,7 @@
 
 export interface ISequence {
+	typeName: string;
+
 	/** The sequence components as an array. */
 	array: TypedArray[];
 	/** The sequence length */

--- a/src/lib/models/sequence/vector-sequence.ts
+++ b/src/lib/models/sequence/vector-sequence.ts
@@ -4,6 +4,8 @@ import { Vector } from '../spatial/vector';
 import { ISequence } from './sequence';
 
 export class VectorSequence implements ISequence {
+	typeName = 'VectorSequence';
+
 	array: TypedArray[];
 	components = ['x', 'y', 'z'];
 
@@ -377,5 +379,10 @@ export class VectorSequence implements ISequence {
 		}
 
 		return result ? result : new VectorSequence(x, y, z, this.frameRate);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	static isVectorSequence(object: any): object is VectorSequence {
+		return object?.typeName === 'VectorSequence';
 	}
 }

--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -395,15 +395,15 @@ export class Signal implements IDataSequence {
 				this._type = SignalType.Float32Array;
 			}
 		}
-		else if (value instanceof Joint) {
+		else if (value instanceof Joint || Joint.isJoint(value)) {
 			this._value.joint = value;
 			this._type = SignalType.Joint;
 		}
-		else if (value instanceof ForcePlate) {
+		else if (value instanceof ForcePlate || ForcePlate.isForcePlate(value)) {
 			this._value.forcePlate = value;
 			this._type = SignalType.ForcePlate;
 		}
-		else if (value instanceof Segment) {
+		else if (value instanceof Segment || Segment.isSegment(value)) {
 			this._value.segment = value;
 			this._type = SignalType.Segment;
 		}
@@ -411,11 +411,11 @@ export class Signal implements IDataSequence {
 			this._value.string = value;
 			this._type = SignalType.String;
 		}
-		else if (value instanceof VectorSequence) {
+		else if (value instanceof VectorSequence || VectorSequence.isVectorSequence(value)) {
 			this._value.vectorSequence = value;
 			this._type = SignalType.VectorSequence;
 		}
-		else if (value instanceof PlaneSequence) {
+		else if (value instanceof PlaneSequence || PlaneSequence.isPlaneSequence(value)) {
 			this._value.planeSequence = value;
 			this._type = SignalType.PlaneSequence;
 		}
@@ -458,6 +458,7 @@ export class Signal implements IDataSequence {
 	getFloat32ArrayArrayValue(): Float32Array[] {
 		return this._value.numberArrayArray;
 	}
+
 	getJointValue(): Joint | null {
 		return this._value.joint;
 	}

--- a/src/lib/models/spatial/quaternion.ts
+++ b/src/lib/models/spatial/quaternion.ts
@@ -8,6 +8,10 @@ export class Quaternion {
 	static tmpQuat1: Quaternion = new Quaternion(0, 0, 0, 1);
 	/** Quaternion instance used for performance reasons. */
 	static tmpQuat2: Quaternion = new Quaternion(0, 0, 0, 1);
+	/** Quaternion instance used for performance reasons. */
+	static tmpQuat3: Quaternion = new Quaternion(0, 0, 0, 1);
+	/** Quaternion instance used for performance reasons. */
+	static tmpQuat4: Quaternion = new Quaternion(0, 0, 0, 1);
 
 	/**
 	 * Creates a new Quaternion from the specified values.

--- a/src/lib/processing/arithmetic.ts
+++ b/src/lib/processing/arithmetic.ts
@@ -1,7 +1,6 @@
 import { Marker } from '../models/marker';
 import { PropertyType } from '../models/property';
 import { Segment } from '../models/segment';
-import { ISequence } from '../models/sequence/sequence';
 import { Signal, SignalType } from '../models/signal';
 import { StepCategory, StepClass } from '../step-registry';
 import { Arithmetic, ArithmeticOp } from '../utils/math/arithmetic';
@@ -171,7 +170,7 @@ export class BaseArithmeticStep extends BaseStep {
 			}
 		}
 
-		const operands = inputs.map(input => (input as ISequence).array.filter(x => x !== undefined)).filter(a => !!a).map(a => a.length === 1 ? a[0] : a);
+		const operands = inputs.map(input => input.array.filter(x => x !== undefined)).filter(a => !!a).map(a => a.length === 1 ? a[0] : a);
 
 		if (!operands.length) throw new ProcessingError('No operands given.');
 


### PR DESCRIPTION
Problem
Noisy kinetic were sometimes found, especially at the Hip joint
The issue was coming from the tmpQuat that were used in the ensureContinuity method

Solution
Create 2 extra instances

### Checklist
- [N/A] Test case implemented
- [x] Test coverage 100%
- [x] Tested on a few problematic reports 
- [N/A] Tested inside a yaml pipeline
- [N/A] Documentation added
