### PR TITLE
Fix issue in SequenceUtil - sequenceByFrameMap when frame maps contain equal frame values

### DIFF
--- a/src/lib/utils/sequence.spec.ts
+++ b/src/lib/utils/sequence.spec.ts
@@ -18,6 +18,15 @@ test('SequenceUtil - sequenceByFrameMap - 2 inputs', (t) => {
 	t.deepEqual(res.map(s => s.getValue()), [f32(1, 5, 8), f32(3, 6, 9)]);
 });
 
+test('SequenceUtil - sequenceByFrameMap - 2 inputs, some with equal indices', (t) => {
+	const res = SequenceUtil.sequenceByFrameMap(
+		s1.getFrames(i32(3, 5, 8)),
+		s1.getFrames(i32(3, 6, 7, 9)),
+	);
+
+	t.deepEqual(res.map(s => s.getValue()), [f32(3, 5, 8), f32(3, 6, 9)]);
+});
+
 test('SequenceUtil - sequenceByFrameMap - 2 inputs, reversed order', (t) => {
 	const res = SequenceUtil.sequenceByFrameMap(
 		s1.getFrames(i32(3, 6, 7, 9)),

--- a/src/lib/utils/sequence.ts
+++ b/src/lib/utils/sequence.ts
@@ -39,8 +39,14 @@ export class SequenceUtil {
 				for (let i = colRowIndex[colIndex]; i < col.length; i++) {
 					if (col[i] >= currFrame) {
 						colRowIndex[colIndex] = i;
-						currFrame = col[i];
 						currRow.push(i);
+
+						if (col[i] === currFrame) {
+							currFrame++;
+						}
+						else {
+							currFrame = col[i];
+						}
 						break;
 					}
 				}


### PR DESCRIPTION
This PR fixes an infinite loop bug when two signals includes the same frame in their respective frame maps.

When running `SequenceUtil.sequenceByFrameMap`, it now ensures that the frames are progressed and doesn't get stuck.

Pull request description...

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [N/A] Documentation added


Work item: [AB#38279](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/38279)