### PR TITLE
Handle empty signals after running sequence ordering

### DIFF
--- a/src/lib/processing/arithmetic.ts
+++ b/src/lib/processing/arithmetic.ts
@@ -164,6 +164,8 @@ export class BaseArithmeticStep extends BaseStep {
 
 			inputs = SequenceUtil.sequenceByFrameMap(...inputs);
 
+			if (!inputs.length) throw new ProcessingError('The operands could not be processed in the specified frame sequence order.');
+
 			if (this.frameSequenceOrder === FrameSequenceOperandOrder.Reverse) {
 				// Restore input order.
 				inputs.reverse();

--- a/src/lib/utils/sequence.spec.ts
+++ b/src/lib/utils/sequence.spec.ts
@@ -8,7 +8,6 @@ const f32 = (...arr: number[]) => Float32Array.from(arr);
 const i32 = (...arr: number[]) => Uint32Array.from(arr);
 
 const s1 = new Signal(f32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
-
 test('SequenceUtil - sequenceByFrameMap - 2 inputs', (t) => {
 	const res = SequenceUtil.sequenceByFrameMap(
 		s1.getFrames(i32(1, 5, 8)),
@@ -58,4 +57,13 @@ test('SequenceUtil - sequenceByFrameMap - not all signals have frames', (t) => {
 	t.is(res.length, 2);
 	t.is(res[0], s1);
 	t.is(res[1], s1Frames);
+});
+
+test('SequenceUtil - sequenceByFrameMap - 2 inputs - wrong order', (t) => {
+	const res = SequenceUtil.sequenceByFrameMap(
+		s1.getFrames(i32(3)),
+		s1.getFrames(i32(1)),
+	);
+
+	t.is(res.length, 0);
 });

--- a/src/lib/utils/sequence.ts
+++ b/src/lib/utils/sequence.ts
@@ -58,7 +58,9 @@ export class SequenceUtil {
 
 			indexRows.push(currRow);
 		}
-		
+
+		if (!indexRows.length) return [];
+
 		// Get indices by column instead of rows.
 		let [indexColumns] = indexRows;
 		indexColumns = indexColumns.map((value, column) => indexRows.map(row => row[column]));


### PR DESCRIPTION
Gracefully handle error when no signals are produced after running sequence ordering.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [N/A] Documentation added


Work item: [AB#38688](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/38688)