### PR TITLE
Handle nulls when calculating space based on a segment

### DIFF
--- a/src/lib/processing/space.spec.ts
+++ b/src/lib/processing/space.spec.ts
@@ -8,9 +8,10 @@ import { Signal } from '../models/signal';
 
 import { Space } from './space';
 
+// Includes null values, which should be ignored.
 const hipsTowardsX = new Segment('Hips', 
-	new VectorSequence( f32(1076.73, 1075.956), f32(324.277, 324.182), f32(1000.48, 998.467) ),
-	new QuaternionSequence( f32(-0.076565, -0.076792), f32(0.030934, 0.028671), f32(-0.720501, -0.720117), f32(0.68852, 0.688994 ) )
+	new VectorSequence( f32(1076.73, 1075.956, null), f32(324.277, null, 324.182), f32(null, 1000.48, 998.467) ),
+	new QuaternionSequence( f32(-0.076565, null, -0.076792), f32(null, 0.030934, 0.028671), f32(-0.720501, null, -0.720117), f32(0.68852, 0.688994, null) )
 );
 
 const hipsTowardsY = new Segment('Hips', 

--- a/src/lib/processing/space.ts
+++ b/src/lib/processing/space.ts
@@ -101,9 +101,14 @@ export class Space extends BaseStep {
 			ez[i] = Vector.tmpVec1.z;
 		}
 
-		const exUnwrapped = AngleUtil.unwrapAngles(ex.map((v) => v * 180 / Math.PI));
-		const eyUnwrapped = AngleUtil.unwrapAngles(ey.map((v) => v * 180 / Math.PI));
-		const ezUnwrapped = AngleUtil.unwrapAngles(ez.map((v) => v * 180 / Math.PI));
+		// Remove nulls and NaNs.
+		const exFiltered = ex.filter(v => !isNaN(v) && v !== null);
+		const eyFiltered = ey.filter(v => !isNaN(v) && v !== null);
+		const ezFiltered = ez.filter(v => !isNaN(v) && v !== null);
+
+		const exUnwrapped = AngleUtil.unwrapAngles(exFiltered.map((v) => v * 180 / Math.PI));
+		const eyUnwrapped = AngleUtil.unwrapAngles(eyFiltered.map((v) => v * 180 / Math.PI));
+		const ezUnwrapped = AngleUtil.unwrapAngles(ezFiltered.map((v) => v * 180 / Math.PI));
 		const avgEulerUnwrapped = new Vector(mean(exUnwrapped), mean(eyUnwrapped), mean(ezUnwrapped));
 		const z = avgEulerUnwrapped.z;
 


### PR DESCRIPTION
This PR fixes an error when calculating the mean orientation of a segment for use in a space. 
Now, any nulls are removed before the mean is calculated.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [N/A] Documentation added

Work item: [AB#38688](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/38688)