### PR TITLE
Access signal properties

### DIFF
--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -10,6 +10,7 @@
       - [EMG channels](#emg-channels)
       - [Force plates](#force-plates)
     + [Components](#components)
+    + [Properties](#properties)
   * [Mixed inputs](#mixed-inputs)
   * [Variable inputs](#variable-inputs)
     + [Static variables](#static-variables)
@@ -27,7 +28,11 @@
   * [Output immutability](#output-immutability)
   * [Output naming for reports](#output-naming-for-reports)
 - [Measurement filtering](#measurement-filtering)
-  * [Filter options](#filter-options)
+  * [Available filters](#available-filters)
+  * [Filter by measurement name](#filter-by-measurement-name)
+  * [Filter by field values](#filter-by-field-values)
+  * [Filter by force assignment](#filter-by-force-assignment)
+  * [Filter by match index](#filter-by-match-index)
   * [Output nodes for specific measurements](#output-nodes-for-specific-measurements)
 
 
@@ -136,6 +141,13 @@ For example, if you only want to use the **x** component of the Hips segment, yo
 ```yaml
 - step1: Hips.x
 ```
+For more details on how to use components, [read here](./working-with-data#components).
+
+### Properties
+
+Named signals may have properties, similar to components, that are of various types but are generally not usable in the same way as a component. You access properties in the same way as components, by typing a dot (.) followed by the name (or path) of the property.
+
+For more details on how to use properties, [read here](./working-with-data#properties).
 
 ## Mixed inputs
 

--- a/docs/working-with-data.md
+++ b/docs/working-with-data.md
@@ -10,6 +10,7 @@ Calqulus can import the following kinds of data from your measurements:
 * EMG
 * Kinetics (accessible via *joints*)
 * Force plate
+* Events
 
 ## Importing data
 To access data in a Calqulus pipeline you can either reference it by name
@@ -142,7 +143,7 @@ _Example of multiplying the x and y component of a marker._
 **Power**
 * p
 
-### Force plate
+#### Force plate
 **Center of pressure**
 * x, y, z
 
@@ -151,6 +152,28 @@ _Example of multiplying the x and y component of a marker._
 
 **Moment**
 * mx, my, mz
+
+## Properties
+A similar concept to components are "properties". A property can be any type of data while components are series of data, where each component has the same length. Properties are not included when a signal is imported into a step and are not automatically exported, but can be explicitly imported into a pipeline.
+
+Properties are accessed in the same way as components, using the dot (.) notation.
+
+_Example of creating LON and LOFF events from the `LeftFootContact.events.on` and `LeftFootContact.events.off` properties._
+```yaml
+- event: LON
+  steps:
+   - import: LeftFootContact.events.on
+
+- event: LOFF
+  steps:
+   - import: LeftFootContact.events.off
+```
+
+### Available properties
+
+#### Joint
+* `events.on`
+* `events.off`
 
 ## Quick reference
 ### Segments

--- a/docs/working-with-data.md
+++ b/docs/working-with-data.md
@@ -172,8 +172,19 @@ _Example of creating LON and LOFF events from the `LeftFootContact.events.on` an
 ### Available properties
 
 #### Joint
-* `events.on`
+* `events.on` 
 * `events.off`
+
+The `on` and `off` events indicate the frames where the foot has started and stopped being assigned to a force plate. This event filters out cycles where the foot is already assigned to the force plate at the immediate beginning or end of the measurement.
+
+_*Note:* Only available on `LeftFootContact` and `RightFootContact` joints._
+
+* `events.loadStart`
+* `events.loadEnd`
+
+The `loadStart` and `loadEnd` events indicate the frames where the foot has started and stopped being assigned to a force plate. This event *includes* cycles where the foot is already assigned to the force plate at the immediate beginning or end of the measurement.
+
+_*Note:* Only available on `LeftFootContact` and `RightFootContact` joints._
 
 ## Quick reference
 ### Segments

--- a/src/lib/models/joint.spec.ts
+++ b/src/lib/models/joint.spec.ts
@@ -1,5 +1,7 @@
 import test from 'ava';
 
+import { f32 } from '../../test-utils/mock-step';
+
 import { Joint } from './joint';
 import { VectorSequence } from './sequence/vector-sequence';
 
@@ -87,6 +89,60 @@ test('Joint - getComponent', (t) => {
 	}
 
 	t.is(joint.getComponent('wrongComponent'), undefined);
+});
+
+test('Joint - get and set properties', (t) => {
+	const joint = new Joint(
+		'test',
+		new VectorSequence(fakeArray, fakeArray, fakeArray, 300),
+		new VectorSequence(fakeArray, fakeArray, fakeArray, 300),
+		new VectorSequence(fakeArray, fakeArray, fakeArray, 300),
+		fakeArray,
+		300
+	);
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: undefined });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: undefined });
+
+	joint.setProperty('events.on', f32(1, 2, 3));
+	joint.setProperty('events.off', f32(4, 5, 6));
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: f32(1, 2, 3) });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: f32(4, 5, 6) });
+
+	joint.setProperty('events.on', f32(7, 8, 9));
+	joint.setProperty('events.off', f32(10, 11, 12));
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: f32(7, 8, 9) });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: f32(10, 11, 12) });
+
+	joint.setProperty('events.on', 'test');
+	joint.setProperty('events.off', 'test');
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: 'test' });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: 'test' });
+
+	joint.setProperty('events.on', 1);
+	joint.setProperty('events.off', 2);
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: 1 });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: 2 });
+
+	joint.setProperty('events.on', undefined);
+	joint.setProperty('events.off', undefined);
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: undefined });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: undefined });
+
+	joint.setProperty('events.on', null);
+	joint.setProperty('events.off', null);
+
+	t.deepEqual(joint.getProperty('events.on'), { name: 'events.on', value: null });
+	t.deepEqual(joint.getProperty('events.off'), { name: 'events.off', value: null });
+
+	t.throws(() => joint.setProperty('wrongProperty', 'test'));
+
+	t.is(joint.getProperty('wrongProperty'), undefined);
 });
 
 test('Joint - length', (t) => {

--- a/src/lib/models/joint.ts
+++ b/src/lib/models/joint.ts
@@ -1,4 +1,3 @@
-import { PropertyType } from './property';
 import { Segment } from './segment';
 import { IDataSequence, ISequence, ISequenceDataProperties, ISequenceProperty } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';

--- a/src/lib/models/joint.ts
+++ b/src/lib/models/joint.ts
@@ -1,12 +1,17 @@
+import { PropertyType } from './property';
 import { Segment } from './segment';
-import { IDataSequence, ISequence } from './sequence/sequence';
+import { IDataSequence, ISequence, ISequenceDataProperties, ISequenceProperty } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 
-export class Joint implements ISequence, IDataSequence {
+export class Joint implements ISequence, IDataSequence, ISequenceDataProperties {
 	readonly typeName = 'Joint';
 
 	array: TypedArray[];
 	components = ['x', 'y', 'z', 'fx', 'fy', 'fz', 'mx', 'my', 'mz', 'p'];
+	properties = [
+		{ name: 'events.on', value: undefined },
+		{ name: 'events.off', value: undefined },
+	];
 	distalSegment: Segment;
 	proximalSegment: Segment;
 
@@ -85,6 +90,32 @@ export class Joint implements ISequence, IDataSequence {
 		const index = this.components.indexOf(component);
 
 		return this.array[index];
+	}
+
+	/**
+	 * Returns a [[ISequenceProperty]] from the properties array.
+	 * If the property is not found, returns undefined.
+	 * @param name 
+	 */
+	getProperty(name: string): ISequenceProperty | undefined {
+		return this.properties.find(p => p.name === name);
+	}
+
+	/**
+	 * Sets a property value in the properties array.
+	 * If the property is not found, throws an error.
+	 * @param name 
+	 * @param value
+	 */
+	setProperty(name: string, value: number | string | TypedArray): void {
+		const property = this.getProperty(name);
+
+		if (property) {
+			property.value = value;
+		}
+		else {
+			throw new Error(`Property ${name} not found.`);
+		}
 	}
 
 	/**

--- a/src/lib/models/joint.ts
+++ b/src/lib/models/joint.ts
@@ -10,6 +10,8 @@ export class Joint implements ISequence, IDataSequence, ISequenceDataProperties 
 	properties = [
 		{ name: 'events.on', value: undefined },
 		{ name: 'events.off', value: undefined },
+		{ name: 'events.loadStart', value: undefined },
+		{ name: 'events.loadEnd', value: undefined },
 	];
 	distalSegment: Segment;
 	proximalSegment: Segment;

--- a/src/lib/models/sequence/sequence.ts
+++ b/src/lib/models/sequence/sequence.ts
@@ -1,4 +1,3 @@
-
 export interface ISequence {
 	typeName: string;
 
@@ -11,6 +10,19 @@ export interface ISequence {
 
 	/** Returns the series for the specified component. */
 	getComponent(component: string): TypedArray;
+}
+
+export interface ISequenceProperty {
+	/** The property name, including path. */
+	name: string;
+	/** The property value. */
+	value: number | string | TypedArray;
+}
+
+export interface ISequenceDataProperties {
+	properties: ISequenceProperty[];
+	getProperty(name: string): ISequenceProperty;
+	setProperty(name: string, value: number | string | TypedArray): void;
 }
 
 export interface IDataSequence {

--- a/src/lib/models/signal.spec.ts
+++ b/src/lib/models/signal.spec.ts
@@ -751,6 +751,9 @@ test('Signal - clone', (t) => {
 	source.targetSpace = space;
 	source.cycles = cycles;
 	source.resultType = ResultType.Scalar;
+	source.originalSignal = source.clone();
+	source.component = 'x';
+	source.property = { name: 'test', value: 5 };
 
 	const clone = source.clone();
 
@@ -764,6 +767,9 @@ test('Signal - clone', (t) => {
 	t.is(clone.resultType, source.resultType);
 	t.is(clone.getValue(), source.getValue());
 	t.is(clone.type, source.type);
+	t.is(clone.originalSignal, source.originalSignal);
+	t.is(clone.component, source.component);
+	t.deepEqual(clone.property, source.property);
 });
 
 test('Signal - clone with no value', (t) => {

--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -7,7 +7,7 @@ import { Joint } from './joint';
 import { Marker } from './marker';
 import { Segment } from './segment';
 import { PlaneSequence } from './sequence/plane-sequence';
-import { IDataSequence } from './sequence/sequence';
+import { IDataSequence, ISequenceProperty } from './sequence/sequence';
 import { VectorSequence } from './sequence/vector-sequence';
 
 /**
@@ -91,6 +91,13 @@ export class Signal implements IDataSequence {
 	 * If set, the original signal is available in [[Signal.originalSignal]].
 	 */
 	public component: string;
+
+	/**
+	 * The property of the original signal that this signal is derived from.
+	 * 
+	 * If set, the original signal is available in [[Signal.originalSignal]].
+	 */
+	public property?: ISequenceProperty;
 	/** 
 	 * Applied event cycles of this signal. This could mean that 
 	 * the data is either compacted or of its original length. 

--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -746,6 +746,9 @@ export class Signal implements IDataSequence {
 		out.frameRate = this.frameRate;
 		out.cycles = this.cycles;
 		out.isEvent = this.isEvent;
+		out.originalSignal = this.originalSignal;
+		out.component = this.component;
+		out.property = this.property;
 
 		if (this._resultType) {
 			out.resultType = this._resultType;


### PR DESCRIPTION
## Properties
Properties are a similar concept to components. A property can be any type of data while components are series of data, where each component has the same length. Properties are not included when a signal is imported into a step and are not automatically exported, but can be explicitly imported into a pipeline.

Properties are accessed in the same way as components, using the dot (.) notation.

### Available properties

#### Joint
* `events.on`
* `events.off`

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [x] Documentation added

### Example
Show example in yaml file...

_Example of creating LON and LOFF events from the `LeftFootContact.events.on` and `LeftFootContact.events.off` properties._
```yaml
- event: LON
  steps:
   - import: LeftFootContact.events.on

- event: LOFF
  steps:
   - import: LeftFootContact.events.off
```

Work item: [AB#39438](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/39438)