### PR TITLE
Cycle detection algorithm: ignore repeated start events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001621",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
-      "integrity": "sha1-Sty0Q8i5yDA+BEmDGPmHYWuP6i4=",
+      "version": "1.0.30001695",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha1-Od/t2PlIURMnlf35t50pZZrZxNQ=",
       "dev": true,
       "funding": [
         {
@@ -10134,9 +10134,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001621",
-      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
-      "integrity": "sha1-Sty0Q8i5yDA+BEmDGPmHYWuP6i4=",
+      "version": "1.0.30001695",
+      "resolved": "https://pkgs.dev.azure.com/Qualisys/Dev/_packaging/AppTeamPrivateNPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha1-Od/t2PlIURMnlf35t50pZZrZxNQ=",
       "dev": true
     },
     "cbor": {

--- a/src/lib/utils/events.spec.ts
+++ b/src/lib/utils/events.spec.ts
@@ -12,9 +12,61 @@ test('EventUtil - eventSequence', (t) => {
 	const spans = EventUtil.eventSequence(framesA, framesB);
 
 	t.deepEqual(spans, [
-		{ start: 2, end: 4 },
+		{ start: 3, end: 4 },
 		{ start: 7, end: 8 },
 		{ start: 10, end: 12 },
+	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+	const framesBShuffle = ArrayTestUtil.shuffle(framesB);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesBShuffle);
+
+	t.deepEqual(spansShuffle, spans);
+
+	// Test empty input
+	const spans2 = EventUtil.eventSequence(framesA, []);
+
+	t.deepEqual(spans2, []);
+});
+
+test('EventUtil - eventSequence - identical frames', (t) => {
+	const framesA = [2, 3, 7, 10, 16];
+
+	const spans = EventUtil.eventSequence(framesA, framesA);
+
+	t.deepEqual(spans, [
+		{ start: 2, end: 3 },
+		{ start: 3, end: 7 },
+		{ start: 7, end: 10 },
+		{ start: 10, end: 16 },
+	]);
+
+	// Test random shuffle
+	const framesAShuffle = ArrayTestUtil.shuffle(framesA);
+
+	const spansShuffle = EventUtil.eventSequence(framesAShuffle, framesAShuffle);
+
+	t.deepEqual(spansShuffle, spans);
+
+	// Test empty input
+	const spans2 = EventUtil.eventSequence(framesA, []);
+
+	t.deepEqual(spans2, []);
+});
+
+test('EventUtil - eventSequence - multiple start events before end event', (t) => {
+	// Should use the last start event before the end event as the start of the span.
+	const framesA = [2, 3, 7, 10, 12, 16];
+	const framesB = [4, 8, 9, 18];
+
+	const spans = EventUtil.eventSequence(framesA, framesB);
+
+	t.deepEqual(spans, [
+		{ start: 3, end: 4 },
+		{ start: 7, end: 8 },
+		{ start: 16, end: 18 },
 	]);
 
 	// Test random shuffle

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -47,6 +47,7 @@ export class EventUtil {
 		let nextStart: number;
 		let nextToIndex = 0;
 
+		fromLoop:
 		for (let i = 0; i < fromFrames.length; i++) {
 			const currFrame = fromFrames[i];
 			if (nextStart !== undefined && currFrame < nextStart) continue;
@@ -54,6 +55,13 @@ export class EventUtil {
 
 			for (let j = nextToIndex; j < toFrames.length; j++) {
 				if (toFrames[j] > currFrame) {
+					// Check if the next start value is still smaller than the current end value.
+					if (i < fromFrames.length - 1 && fromFrames[i + 1] < toFrames[j]) {
+						// If so, skip to the next start value.
+						nextToIndex = j;
+						continue fromLoop;
+					}
+
 					pairs.push({
 						start: currFrame, 
 						end: toFrames[j]


### PR DESCRIPTION
This PR changes the cycle detection algorithm to ignore repeated start events if there are no end events between them. It has the effect that it will pick the _latest_ start event before any end event. Previously, the algorithm picked the first start event and ignored any subsequent start events until it found an end event.

### Checklist
- [ ] Test case implemented
- [ ] Test coverage 100%
- [ ] Tested inside a yaml pipeline
- [ ] Documentation added

### Example
Consider the following event sequence:

```
(1) L_MID_STANCE
(2) LFS
(3) LFS
(4) L_MID_STANCE
(5) LFS
(6) L_MID_STANCE
```

Normalizing between LFS and L_MID_STANCE would previously produce the following sequence:
```
(2) => (4)
(5) => (6)
```

With this change, these cycles are used:
```
(3) => (4)
(5) => (6)
```



Work item: AB#38952