### PR TITLE
Updated docs regarding global variables for body mass

### DIFF
--- a/docs/body-mass.md
+++ b/docs/body-mass.md
@@ -19,9 +19,9 @@ Force magnitudes from all active force plates are then combined frame by frame. 
 
 Subsequently, all frames where the combined force magnitude is below 50N are filtered out. If no frames exceed this threshold, the force plate data is ignored. Otherwise, the median of the remaining frames is divided by the gravitational acceleration to estimate the body mass.
 
-Finally, if the estimated body mass from the force plates exceeds 200kg, the data is deemed invalid and ignored.
+Finally, if the estimated body mass from the force plates exceeds 400kg, the data is deemed invalid and ignored.
 
-If Calqulus is unable to determine the mass using the force plates at any point in this process, it will fall back to using the weight defined in the session fields or the default weight, as specified by the `Body weight mode`.
+If Calqulus is unable to determine the mass using the force plates at any point in this process, it will not calculate the inverse dynamics for the session.
 
 ## Reading Body Mass from Fields
 
@@ -37,18 +37,18 @@ When the `Body weight mode` is set to `Automatic`, Calqulus resolves the body ma
 
 1. **Force Plates:** Use force plate data if available and valid.
 2. **Field Value:** Use the value from the `Mass` or `Weight` field if it exists and is nonzero.
-3. **Default Weight:** Otherwise, use the default weight (65kg).
+3. **Default:** Otherwise, no mass is used and inverse dynamics calculations are skipped.
 
 ### Force Plate Mode
 
 When the `Body weight mode` is set to `From force plates`, Calqulus follows this order:
 
 1. **Force Plates:** Use force plate data if available and valid.
-2. **Default Weight:** Otherwise, use the default weight (65kg).
+2. **Default:** Otherwise, skip inverse dynamics calculations.
 
 ### Entered Weight Mode
 
 When the `Body weight mode` is set to `Entered`, Calqulus follows this order:
 
 1. **Field Value:** Use the value from the `Mass` or `Weight` field if it exists and is nonzero.
-2. **Default Weight:** Otherwise, use the default weight (65kg).
+2. **Default:** Otherwise, skip inverse dynamics calculations.

--- a/docs/body-mass.md
+++ b/docs/body-mass.md
@@ -1,6 +1,7 @@
 # Body Mass
 
-The body mass (i.e., the weight of the subject) is essential for calculating inverse dynamics. During session processing, Calqulus determines the subject's body mass using one of the following sources:
+Body mass (or body weight) is crucial for calculating inverse dynamics—in Calqulus processing, these terms are used interchangeably to denote the subject’s weight in kilograms.
+During session processing, Calqulus determines the subject's body mass using one of the following sources:
 
 - Force data from force plates during a static measurement.
 - The value provided in the `Mass` or `Weight` field in QTM.

--- a/docs/body-mass.md
+++ b/docs/body-mass.md
@@ -1,0 +1,53 @@
+# Body Mass
+
+The body mass (i.e., the weight of the subject) is essential for calculating inverse dynamics. During session processing, Calqulus determines the subject's body mass using one of the following sources:
+
+- Force data from force plates during a static measurement.
+- The value provided in the `Mass` or `Weight` field in QTM.
+
+## Reading Body Mass from Force Plates
+
+Calqulus first searches for a static measurement within the session. If multiple static files are found, the last one—based on alphabetical order—is selected.
+
+Once a static measurement is identified, Calqulus checks for the presence of one or more force plates. For each force plate:
+
+- The force magnitude is computed for every frame.
+- If the median force magnitude is below 50N, the plate is considered inactive and is ignored.
+
+Force magnitudes from all active force plates are then combined frame by frame. The standard deviation of these combined forces is calculated; if this value exceeds 50, it indicates that the subject was not stationary during the static measurement, and the force plate data is discarded.
+
+Subsequently, all frames where the combined force magnitude is below 50N are filtered out. If no frames exceed this threshold, the force plate data is ignored. Otherwise, the median of the remaining frames is divided by the gravitational acceleration to estimate the body mass.
+
+Finally, if the estimated body mass from the force plates exceeds 200kg, the data is deemed invalid and ignored.
+
+If Calqulus is unable to determine the mass using the force plates at any point in this process, it will fall back to using the weight defined in the session fields or the default weight, as specified by the `Body weight mode`.
+
+## Reading Body Mass from Fields
+
+If the session includes a `Mass` or `Weight` field, its value is validated to ensure it is numeric and nonzero. Should the field be missing or contain an invalid value, Calqulus disregards it and uses the default weight instead.
+
+## Specifying a Mode
+
+The source used for determining body mass can be explicitly defined via the `Body weight mode` field in QTM. If this field is not provided, the system defaults to `Automatic` mode.
+
+### Automatic Mode
+
+When the `Body weight mode` is set to `Automatic`, Calqulus resolves the body mass in the following order:
+
+1. **Force Plates:** Use force plate data if available and valid.
+2. **Field Value:** Use the value from the `Mass` or `Weight` field if it exists and is nonzero.
+3. **Default Weight:** Otherwise, use the default weight (65kg).
+
+### Force Plate Mode
+
+When the `Body weight mode` is set to `From force plate`, Calqulus follows this order:
+
+1. **Force Plates:** Use force plate data if available and valid.
+2. **Default Weight:** Otherwise, use the default weight (65kg).
+
+### Entered Weight Mode
+
+When the `Body weight mode` is set to `Entered`, Calqulus follows this order:
+
+1. **Field Value:** Use the value from the `Mass` or `Weight` field if it exists and is nonzero.
+2. **Default Weight:** Otherwise, use the default weight (65kg).

--- a/docs/body-mass.md
+++ b/docs/body-mass.md
@@ -41,7 +41,7 @@ When the `Body weight mode` is set to `Automatic`, Calqulus resolves the body ma
 
 ### Force Plate Mode
 
-When the `Body weight mode` is set to `From force plate`, Calqulus follows this order:
+When the `Body weight mode` is set to `From force plates`, Calqulus follows this order:
 
 1. **Force Plates:** Use force plate data if available and valid.
 2. **Default Weight:** Otherwise, use the default weight (65kg).

--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -180,7 +180,7 @@ It is possible to get information about the session or measurement by importing 
 - `$analogFramerate` - returns the frame rate used for analog signals (EMG, etc.) for the measurement.
 - `$length` - returns the number of (marker) frames of the measurement.
 - `$bodyMass` - returns the inferred or measured body mass (in kg) used for inverse dynamics for the session. It may come from a field or measured from a static measurement, depending on the session `Body weight mode` field.
-- `$bodyMassSource` - returns the source for the body mass above. It may have one of the following values: `From force plate`, `Entered`, or `Default`. The latter is returned when the body mass could not be derived using any of the other sources. 
+- `$bodyMassSource` - returns the source for the body mass above. It may have one of the following values: `From force plates`, `Entered`, or `Default`. The latter is returned when the body mass could not be derived using any of the other sources. 
 
 For more information about how Calqulus sources the body mass, [click here](./body-mass.md).
 

--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -182,6 +182,8 @@ It is possible to get information about the session or measurement by importing 
 - `$bodyMass` - returns the inferred or measured body mass (in kg) used for inverse dynamics for the session. It may come from a field or measured from a static measurement, depending on the session `Body weight mode` field.
 - `$bodyMassSource` - returns the source for the body mass above. It may have one of the following values: `From force plate`, `Entered`, or `Default`. The latter is returned when the body mass could not be derived using any of the other sources. 
 
+For more information about how Calqulus sources the body mass, [click here](./body-mass.md).
+
 #### Example
 
 ```yaml

--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -179,6 +179,8 @@ It is possible to get information about the session or measurement by importing 
 - `$framerate` - returns the measurement (marker) frame rate in frames per second.
 - `$analogFramerate` - returns the frame rate used for analog signals (EMG, etc.) for the measurement.
 - `$length` - returns the number of (marker) frames of the measurement.
+- `$bodyMass` - returns the inferred or measured body mass (in kg) used for inverse dynamics for the session. It may come from a field or measured from a static measurement, depending on the session `Body weight mode` field.
+- `$bodyMassSource` - returns the source for the body mass above. It may have one of the following values: `From force plate`, `Entered`, or `Default`. The latter is returned when the body mass could not be derived using any of the other sources. 
 
 #### Example
 

--- a/docs/working-with-data.md
+++ b/docs/working-with-data.md
@@ -11,6 +11,7 @@ Calqulus can import the following kinds of data from your measurements:
 * Kinetics (accessible via *joints*)
 * Force plate
 * Events
+* Body mass
 
 ## Importing data
 To access data in a Calqulus pipeline you can either reference it by name


### PR DESCRIPTION
Adds documentation about global variables for getting body mass (the same body mass used for inverse dynamics calculations). The mass either comes from a field or from force plates in a static measurement.

### Example

``` yaml
- parameter: Body Mass
  steps:
    - import: $bodyMass

- parameter: Body Mass Source
  steps:
    - import: $bodyMassSource
```

Work item: [AB#38662](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/38662)