### PR TITLE
Update the measurement object with original marker and segment frame rates

### DIFF
--- a/src/lib/models/measurement.ts
+++ b/src/lib/models/measurement.ts
@@ -6,6 +6,10 @@ import { Segment } from './segment';
 import { Skeleton } from './skeleton';
 
 export interface IMeasurement {
+	originalFrameRate?: {
+		marker: number;
+		segment: number;
+	};
 	analogFrameRate: number;
 	endFrame: number;
 	events: IEvent[];


### PR DESCRIPTION
Used when importing data with varying rates of markers and segments.

Work item: [AB#40241](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/40241)