### PR TITLE
Handle forward slashes within strings in expressions

### DIFF
--- a/src/lib/utils/expression.spec.ts
+++ b/src/lib/utils/expression.spec.ts
@@ -821,68 +821,75 @@ test('parseExpressionOperands - variable inputs', (t) => {
 			{ value: 'operand_1_$field_FieldName', originalValue: '$field(Field Name)', ...defaultResult },
 		]
 	});
+
+	t.deepEqual(parseExpressionOperands('$field(session/Field Name)'), {
+		expression: 'operand_0_$field_sessionFieldName',
+		operands: [
+			{ value: 'operand_0_$field_sessionFieldName', originalValue: '$field(session/Field Name)', ...defaultResult },
+		]
+	});
 });
 
 test('parseExpressionOperands - variable inputs - with options', (t) => {
-	t.deepEqual(parseExpressionOperands('$field(Field Name, My Measurement, numeric)'), {
+	t.deepEqual(parseExpressionOperands('$field(Field Name; My Measurement; numeric)'), {
 		expression: 'operand_0_$field_FieldName_MyMeasurement_numeric',
 		operands: [
-			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult },
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult },
 		]
 	});
 
-	t.deepEqual(parseExpressionOperands('!$field(Field Name, My Measurement, numeric)'), {
+	t.deepEqual(parseExpressionOperands('!$field(Field Name; My Measurement; numeric)'), {
 		expression: '!operand_0_$field_FieldName_MyMeasurement_numeric',
 		operands: [
-			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, isInverted: true },
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult, isInverted: true },
 		]
 	});
 
-	t.deepEqual(parseExpressionOperands('exists(hello) && $field(Field Name, My Measurement, numeric)'), {
+	t.deepEqual(parseExpressionOperands('exists(hello) && $field(Field Name; My Measurement; numeric)'), {
 		expression: 'hello && operand_1_$field_FieldName_MyMeasurement_numeric',
 		operands: [
 			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
-			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult },
 		]
 	});
 
-	t.deepEqual(parseExpressionOperands('exists(hello) && !$field(Field Name, My Measurement, numeric)'), {
+	t.deepEqual(parseExpressionOperands('exists(hello) && !$field(Field Name; My Measurement; numeric)'), {
 		expression: 'hello && !operand_1_$field_FieldName_MyMeasurement_numeric',
 		operands: [
 			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
-			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, isInverted: true },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult, isInverted: true },
 		]
 	});
 
-	t.deepEqual(parseExpressionOperands('(exists(hello) && $field(Field Name, My Measurement, numeric))'), {
+	t.deepEqual(parseExpressionOperands('(exists(hello) && $field(Field Name; My Measurement; numeric))'), {
 		expression: '(hello && operand_1_$field_FieldName_MyMeasurement_numeric)',
 		operands: [
 			{ value: 'hello', originalValue: 'hello', ...defaultResult, exists: true },
-			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult },
 		]
 	});
 });
 
 test('parseExpressionOperands - variable inputs - with options - with functions', (t) => {
-	t.deepEqual(parseExpressionOperands('empty($field(Field Name, My Measurement, numeric))'), {
+	t.deepEqual(parseExpressionOperands('empty($field(Field Name; My Measurement; numeric))'), {
 		expression: 'operand_0_$field_FieldName_MyMeasurement_numeric',
 		operands: [
-			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, empty: true },
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult, empty: true },
 		]
 	});
 
-	t.deepEqual(parseExpressionOperands('exists($field(Field Name, My Measurement, numeric))'), {
+	t.deepEqual(parseExpressionOperands('exists($field(Field Name; My Measurement; numeric))'), {
 		expression: 'operand_0_$field_FieldName_MyMeasurement_numeric',
 		operands: [
-			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, exists: true },
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult, exists: true },
 		]
 	});
 
-	t.deepEqual(parseExpressionOperands('(exists($field(Field Name, My Measurement, numeric)) && !empty($field(Field Name, My Measurement, numeric)))'), {
+	t.deepEqual(parseExpressionOperands('(exists($field(Field Name; My Measurement; numeric)) && !empty($field(Field Name; My Measurement; numeric)))'), {
 		expression: '(operand_0_$field_FieldName_MyMeasurement_numeric && !operand_1_$field_FieldName_MyMeasurement_numeric)',
 		operands: [
-			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, exists: true },
-			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name, My Measurement, numeric)', ...defaultResult, empty: true, isInverted: true },
+			{ value: 'operand_0_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult, exists: true },
+			{ value: 'operand_1_$field_FieldName_MyMeasurement_numeric', originalValue: '$field(Field Name; My Measurement; numeric)', ...defaultResult, empty: true, isInverted: true },
 		]
 	});
 });

--- a/src/lib/utils/expression.ts
+++ b/src/lib/utils/expression.ts
@@ -142,19 +142,19 @@ export const parseExpressionOperands = (exp: string): { operands: IExpressionOpe
 			const fieldMatches = v.match(/^\$field\((.*)\)$/);
 
 			if (fieldMatches && fieldMatches.length === 2) {
-				v = '$field_' + fieldMatches[1].split(',').join('_');
+				v = '$field_' + fieldMatches[1].split(';').join('_');
 			}
 
 			// Clean up $prev calls from the expression.
 			const prevMatches = v.match(/^\$prev\((.*)\)$/);
 
 			if (prevMatches && prevMatches.length === 2) {
-				v = '$prev_' + prevMatches[1].split(',').join('_');
+				v = '$prev_' + prevMatches[1].split(';').join('_');
 			}
 
-			// Remove any whitespace from the operands.
-			if (/\s/.test(v)) {
-				v = v.replace(/\s/g, '');
+			// Remove any reserved characters from the operands.
+			if (/[^A-Za-z0-9$_@.]/.test(v)) {
+				v = v.replace(/[^A-Za-z0-9$_@.]/g, '');
 				v = 'operand_' + index + '_' + v;
 			}
 


### PR DESCRIPTION
This PR sanitizes operands in conditional expressions to remove any semantically significant characters.

### Checklist
- [x] Test case implemented
- [x] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [N/A] Documentation added

### Example
Show example in yaml file...

``` yaml
- parameter: MySignal
  steps: 
    - if: $field(session/Test field) == $"Hello world"
      then: 1
      else: 0

```

Work item: [AB#44524](https://dev.azure.com/Qualisys/73dfc6f0-1b8e-4dd7-972d-29fb7d7e0000/_workitems/edit/44524)