### PR TITLE
Change Signal.clone to make deep copy

### DIFF
--- a/src/lib/models/analog.spec.ts
+++ b/src/lib/models/analog.spec.ts
@@ -18,6 +18,23 @@ test('Analog - constructor', (t) => {
 	});
 });
 
+test('Analog - clone', (t) => {
+	const a = new Analog(
+		'test',
+		fakeArray,
+		300
+	);
+
+	const clone = a.clone();
+
+	t.not(clone, a, 'Clone should be a different instance');
+	t.deepEqual(clone.signal, a.signal, 'Signal arrays should be equal in content');
+	t.not(clone.signal, a.signal, 'Signal arrays should not be the same reference');
+	t.is(clone.name, a.name, 'Names should be equal');
+	t.is(clone.frameRate, a.frameRate, 'Frame rates should be equal');
+	t.true(Analog.isAnalog(clone), 'Clone should be recognized as Analog');
+});
+
 test('Analog - length', (t) => {
 	const a = new Analog(
 		'test',

--- a/src/lib/models/analog.ts
+++ b/src/lib/models/analog.ts
@@ -12,6 +12,17 @@ export class Analog implements ISequence, IDataSequence {
 		public frameRate?: number
 	) {}
 
+	/**
+	 * Creates a clone of this analog signal.
+	 */
+	clone(): Analog {
+		return new Analog(
+			this.name,
+			this.signal.slice(),
+			this.frameRate
+		);
+	}
+
 	get length() {
 		if (!this.signal) return 0;
 		return this.signal.length;

--- a/src/lib/models/force-plate.spec.ts
+++ b/src/lib/models/force-plate.spec.ts
@@ -56,6 +56,52 @@ test('ForcePlate - constructor', (t) => {
 	t.is(fp.mz, moment.z);
 });
 
+test('ForcePlate - clone', (t) => {
+	const fpClone = fp.clone();
+
+	// Basic properties
+	t.not(fpClone, fp);
+	t.is(fpClone.name, fp.name);
+
+	// Sequences should be deep clones.
+	t.not(fpClone.centerOfPressure, fp.centerOfPressure);
+	t.not(fpClone.force, fp.force);
+	t.not(fpClone.moment, fp.moment);
+
+	t.deepEqual(fpClone.centerOfPressure, fp.centerOfPressure);
+	t.deepEqual(fpClone.force, fp.force);
+	t.deepEqual(fpClone.moment, fp.moment);
+
+	// Array contents should be equal but not the same reference.
+	t.deepEqual(fpClone.array, fp.array);
+	t.not(fpClone.array, fp.array);
+
+	// Corners, dimensions, offset should be deep cloned.
+	if (fp.corners) {
+		t.deepEqual(fpClone.corners, fp.corners);
+		t.not(fpClone.corners, fp.corners);
+	}
+	if (fp.dimensions) {
+		t.deepEqual(fpClone.dimensions, fp.dimensions);
+		t.not(fpClone.dimensions, fp.dimensions);
+	}
+	if (fp.offset) {
+		t.deepEqual(fpClone.offset, fp.offset);
+		t.not(fpClone.offset, fp.offset);
+	}
+
+	t.is(fpClone.copLevelZ, fp.copLevelZ);
+	t.is(fpClone.copFilter, fp.copFilter);
+
+	// Metadata
+	t.is(fpClone.originalName, fp.originalName);
+	t.is(fpClone.amplifierSerial, fp.amplifierSerial);
+	t.is(fpClone.coordinateSystem, fp.coordinateSystem);
+	t.is(fpClone.model, fp.model);
+	t.is(fpClone.serial, fp.serial);
+	t.is(fpClone.type, fp.type);
+});
+
 test('ForcePlate - setMetadata', (t) => {
 	t.is(fp.amplifierSerial, null);
 	t.is(fp.serial, null);

--- a/src/lib/models/force-plate.ts
+++ b/src/lib/models/force-plate.ts
@@ -35,6 +35,32 @@ export class ForcePlate implements ISequence, IDataSequence {
 		];
 	}
 
+	/**
+	 * Creates a clone of this force plate.
+	 */
+	clone(): ForcePlate {
+		const cloned = new ForcePlate(
+			this.name,
+			this._centerOfPressure.clone(),
+			this._force.clone(),
+			this._moment.clone()
+		);
+
+		cloned.corners = this.corners ? this.corners.map(c => ({ ...c })) : undefined;
+		cloned.dimensions = this.dimensions ? { ...this.dimensions } : undefined;
+		cloned.offset = this.offset ? { ...this.offset } : undefined;
+		cloned.copLevelZ = this.copLevelZ;
+		cloned.copFilter = this.copFilter;
+		cloned.originalName = this.originalName;
+		cloned.amplifierSerial = this.amplifierSerial;
+		cloned.coordinateSystem = this.coordinateSystem;
+		cloned.model = this.model;
+		cloned.serial = this.serial;
+		cloned.type = this.type;
+
+		return cloned;
+	}
+
 	get length() {
 		return this.force.length;
 	}

--- a/src/lib/models/joint.spec.ts
+++ b/src/lib/models/joint.spec.ts
@@ -39,6 +39,59 @@ test('Joint - constructor', (t) => {
 	t.is(joint.power?.length, undefined);
 });
 
+test('Joint - clone', (t) => {
+	const fakeArray1 = Float32Array.from([1, 2, 3]);
+	const fakeArray2 = Float32Array.from([4, 5, 6]);
+	const position = new VectorSequence(fakeArray1, fakeArray1, fakeArray1, 300);
+	const force = new VectorSequence(fakeArray2, fakeArray2, fakeArray2, 300);
+	const moment = new VectorSequence(fakeArray1, fakeArray2, fakeArray1, 300);
+	const power = Float32Array.from([7, 8, 9]);
+	const joint = new Joint(
+		'testClone',
+		position,
+		force,
+		moment,
+		power,
+		300
+	);
+
+	// Set segments and properties.
+	const distalSegment = { id: 'distal' } as any;
+	const proximalSegment = { id: 'proximal' } as any;
+	joint.distalSegment = distalSegment;
+	joint.proximalSegment = proximalSegment;
+	joint.setProperty('events.on', 'onValue');
+	joint.setProperty('events.off', 'offValue');
+
+	const cloned = joint.clone();
+
+	t.not(cloned, joint);
+	t.is(cloned.name, joint.name);
+	t.is(cloned.frameRate, joint.frameRate);
+
+	// Check segments are copied by reference.
+	t.is(cloned.distalSegment, distalSegment);
+	t.is(cloned.proximalSegment, proximalSegment);
+
+	// Check deep clone of properties.
+	t.deepEqual(cloned.properties, joint.properties);
+	t.not(cloned.properties, joint.properties);
+
+	// Check deep clone of arrays.
+	t.deepEqual(Array.from(cloned.x), Array.from(joint.x));
+	t.deepEqual(Array.from(cloned.fx), Array.from(joint.fx));
+	t.deepEqual(Array.from(cloned.mx), Array.from(joint.mx));
+	t.deepEqual(Array.from(cloned.p), Array.from(joint.p));
+
+	// Changing original's property does not affect clone.
+	joint.setProperty('events.on', 'changed');
+	t.not(cloned.getProperty('events.on').value, joint.getProperty('events.on').value);
+
+	// Changing original's power does not affect clone.
+	joint.power[0] = 100;
+	t.not(cloned.power[0], joint.power[0]);
+});
+
 test('Joint - fromArray', (t) => {
 	const joint = Joint.fromArray(
 		'test',

--- a/src/lib/models/joint.ts
+++ b/src/lib/models/joint.ts
@@ -31,6 +31,26 @@ export class Joint implements ISequence, IDataSequence, ISequenceDataProperties 
 		];
 	}
 
+	/**
+	 * Creates a clone of this joint.
+	 */
+	clone(): Joint {
+		const cloned = new Joint(
+			this.name,
+			this._position?.clone(),
+			this._force?.clone(),
+			this._moment?.clone(),
+			this._power ? this._power.slice() : undefined,
+			this.frameRate
+		);
+
+		cloned.distalSegment = this.distalSegment;
+		cloned.proximalSegment = this.proximalSegment;
+		cloned.properties = this.properties.map(p => ({ ...p }));
+
+		return cloned;
+	}
+
 	get force(): VectorSequence { return this._force; }
 	set force(value: VectorSequence) {
 		this._force = value;

--- a/src/lib/models/marker.spec.ts
+++ b/src/lib/models/marker.spec.ts
@@ -22,6 +22,27 @@ test('Marker - constructor', (t) => {
 	});
 });
 
+test('Marker - clone', (t) => {
+	const marker = new Marker(
+		'test',
+		fakeArray,
+		fakeArray,
+		fakeArray,
+		300
+	);
+
+	const clone = marker.clone();
+
+	t.not(clone, marker, 'Clone should be a different instance');
+	t.deepEqual(clone, marker, 'Clone should have the same properties as the original');
+	t.not(clone.x, marker.x, 'Clone x array should be a different instance');
+	t.not(clone.y, marker.y, 'Clone y array should be a different instance');
+	t.not(clone.z, marker.z, 'Clone z array should be a different instance');
+	t.deepEqual(clone.x, marker.x, 'Clone x array should have the same values');
+	t.deepEqual(clone.y, marker.y, 'Clone y array should have the same values');
+	t.deepEqual(clone.z, marker.z, 'Clone z array should have the same values');
+});
+
 test('Marker - fromArray', (t) => {
 	const marker = Marker.fromArray(
 		'test',

--- a/src/lib/models/marker.ts
+++ b/src/lib/models/marker.ts
@@ -24,6 +24,19 @@ export class Marker extends VectorSequence implements ISequence, IDataSequence {
 	}
 
 	/**
+	 * Creates a clone of this marker.
+	 */
+	clone(): Marker {
+		return new Marker(
+			this.name,
+			this.x.slice(),
+			this.y.slice(),
+			this.z.slice(),
+			this.frameRate
+		);
+	}
+
+	/**
 	 * Returns a [[Marker]] from an array, where 
 	 * `x`, `y`, and `z` are included.
 	 * 

--- a/src/lib/models/segment.spec.ts
+++ b/src/lib/models/segment.spec.ts
@@ -57,6 +57,59 @@ test('Segment - constructor', (t) => {
 	});
 });
 
+test('Segment - clone', (t) => {
+	const positionSeq = new VectorSequence(fakeArray2, fakeArray3, fakeArray4, 300);
+	const rotationSeq = new QuaternionSequence(fakeArray, fakeArray, fakeArray, fakeArray);
+	const segment = new Segment(
+		'original',
+		positionSeq,
+		rotationSeq,
+		300
+	);
+
+	// Add additional properties.
+	segment.centerOfMass = new Vector(1, 2, 3);
+	segment.inertia = { clone: () => ({ cloned: true }) } as any;
+	segment.mass = 42;
+	segment.kinematics = {
+		angularAcceleration: { clone: () => 'aa' } as any,
+		angularVelocity: { clone: () => 'av' } as any,
+		linearAcceleration: { clone: () => 'la' } as any,
+		linearVelocity: { clone: () => 'lv' } as any,
+	};
+	segment.parent = new Segment('parent', positionSeq, rotationSeq, 300);
+	segment.contactJoint = { name: 'contact' } as any;
+	segment.distalJoint = { name: 'distal' } as any;
+	segment.proximalJoint = { name: 'proximal' } as any;
+
+	const cloned = segment.clone();
+
+	t.not(cloned, segment);
+	t.is(cloned.name, segment.name);
+	t.deepEqual(cloned.components, segment.components);
+	t.not(cloned.position, segment.position);
+	t.not(cloned.rotation, segment.rotation);
+	t.deepEqual(cloned.position, segment.position);
+	t.deepEqual(cloned.rotation, segment.rotation);
+	t.is(cloned.frameRate, segment.frameRate);
+
+	// Check kinematics are cloned.
+	t.deepEqual(cloned.kinematics.angularAcceleration as unknown as string, 'aa');
+	t.deepEqual(cloned.kinematics.angularVelocity as unknown as string, 'av');
+	t.deepEqual(cloned.kinematics.linearAcceleration as unknown as string, 'la');
+	t.deepEqual(cloned.kinematics.linearVelocity as unknown as string, 'lv');
+
+	// Check centerOfMass, inertia, mass, parent, joints.
+	t.not(cloned.centerOfMass, undefined);
+	t.deepEqual(cloned.centerOfMass, segment.centerOfMass);
+	t.deepEqual(cloned.inertia as unknown as { cloned: boolean }, { cloned: true });
+	t.is(cloned.mass, 42);
+	t.is(cloned.parent, segment.parent);
+	t.is(cloned.contactJoint, segment.contactJoint);
+	t.is(cloned.distalJoint, segment.distalJoint);
+	t.is(cloned.proximalJoint, segment.proximalJoint);
+});
+
 test('Segment - fromArray', (t) => {
 	const segment = Segment.fromArray(
 		'test',

--- a/src/lib/models/segment.ts
+++ b/src/lib/models/segment.ts
@@ -43,6 +43,39 @@ export class Segment implements ISequence, IDataSequence {
 		this.emptyValues = new Float32Array(this._position.x.length).fill(NaN);
 	}
 
+	/**
+	 * Creates a clone of this segment.
+	 */
+	clone(): Segment {
+		const cloned = new Segment(
+			this.name,
+			this._position.clone(),
+			this._rotation.clone(),
+			this.frameRate
+		);
+
+		cloned.components = [...this.components];
+
+		if (this.kinematics) {
+			cloned.kinematics = {
+				angularAcceleration: this.kinematics.angularAcceleration?.clone(),
+				angularVelocity: this.kinematics.angularVelocity?.clone(),
+				linearAcceleration: this.kinematics.linearAcceleration?.clone(),
+				linearVelocity: this.kinematics.linearVelocity?.clone(),
+			};
+		}
+
+		if (this.centerOfMass) { cloned.centerOfMass = this.centerOfMass.clone(); }
+		if (this.inertia) { cloned.inertia = this.inertia.clone(); }
+		if (this.mass !== undefined) { cloned.mass = this.mass; }
+		if (this.parent) { cloned.parent = this.parent; }
+		if (this.contactJoint) { cloned.contactJoint = this.contactJoint; }
+		if (this.distalJoint) { cloned.distalJoint = this.distalJoint; }
+		if (this.proximalJoint) { cloned.proximalJoint = this.proximalJoint; }
+
+		return cloned;
+	}
+
 	get position(): VectorSequence { return this._position; }
 	set position(value: VectorSequence) {
 		this._position = value;

--- a/src/lib/models/sequence/matrix-sequence.spec.ts
+++ b/src/lib/models/sequence/matrix-sequence.spec.ts
@@ -36,6 +36,26 @@ test('MatrixSequence - constructor', (t) => {
 	t.is(mSeq.length, 3);
 });
 
+test('MatrixSequence - clone', (t) => {
+	const original = MatrixSequence.identity(2);
+	const cloned = original.clone();
+
+	// Should not be the same reference.
+	t.not(cloned, original);
+
+	// All arrays should not be the same reference.
+	t.not(cloned.m00, original.m00);
+	t.not(cloned.m11, original.m11);
+
+	// But values should be equal
+	t.deepEqual(Array.from(cloned.getMatrixAtFrame(1)._m), Array.from(original.getMatrixAtFrame(1)._m));
+	t.deepEqual(Array.from(cloned.getMatrixAtFrame(2)._m), Array.from(original.getMatrixAtFrame(2)._m));
+
+	// Changing the clone should not affect the original.
+	cloned.m00[0] = 42;
+	t.not(cloned.m00[0], original.m00[0]);
+});
+
 test('MatrixSequence - getMatrixAtFrame', (t) => {
 	const matrix = mSeq.getMatrixAtFrame(2);
 

--- a/src/lib/models/sequence/matrix-sequence.ts
+++ b/src/lib/models/sequence/matrix-sequence.ts
@@ -34,6 +34,18 @@ export class MatrixSequence {
 	}
 
 	/**
+	 * Creates a clone of this matrix sequence.
+	 */
+	clone(): MatrixSequence {
+		return new MatrixSequence(
+			this.m00.slice(), this.m01.slice(), this.m02.slice(), this.m03.slice(),
+			this.m10.slice(), this.m11.slice(), this.m12.slice(), this.m13.slice(),
+			this.m20.slice(), this.m21.slice(), this.m22.slice(), this.m23.slice(),
+			this.m30.slice(), this.m31.slice(), this.m32.slice(), this.m33.slice()
+		);
+	}
+
+	/**
 	 * Create a Matrix sequence filled with NaNs of the specified
 	 * length .
 	 *

--- a/src/lib/models/sequence/plane-sequence.spec.ts
+++ b/src/lib/models/sequence/plane-sequence.spec.ts
@@ -21,6 +21,26 @@ test('PlaneSequence - constructor', (t) => {
 	});
 });
 
+test('PlaneSequence - clone', (t) => {
+	const a = f32(1, 2, 3);
+	const b = f32(4, 5, 6);
+	const c = f32(7, 8, 9);
+	const d = f32(10, 11, 12);
+
+	const original = new PlaneSequence(a, b, c, d);
+	const clone = original.clone();
+
+	t.not(clone, original, 'Clone should be a different instance');
+	t.deepEqual(clone.a, original.a);
+	t.deepEqual(clone.b, original.b);
+	t.deepEqual(clone.c, original.c);
+	t.deepEqual(clone.d, original.d);
+
+	// Mutate clone and check original is not affected.
+	clone.a[0] = 100;
+	t.not(clone.a[0], original.a[0], 'Mutating clone should not affect original');
+});
+
 test('PlaneSequence - fromArray', (t) => {
 	const pSeq = PlaneSequence.fromArray([fakeArray, fakeArray, fakeArray, fakeArray]);
 

--- a/src/lib/models/sequence/plane-sequence.ts
+++ b/src/lib/models/sequence/plane-sequence.ts
@@ -35,6 +35,18 @@ export class PlaneSequence implements ISequence {
 	}
 
 	/**
+	 * Creates a clone of this plane sequence.
+	 */
+	clone(): PlaneSequence {
+		return new PlaneSequence(
+			this.a.slice(),
+			this.b.slice(),
+			this.c.slice(),
+			this.d.slice()
+		);
+	}
+
+	/**
 	 * Get the number of elements in this sequence.
 	 */
 	get length() { return this.a.length; };

--- a/src/lib/models/sequence/quaternion-sequence.spec.ts
+++ b/src/lib/models/sequence/quaternion-sequence.spec.ts
@@ -20,6 +20,29 @@ test('QuaternionSequence - constructor', (t) => {
 	});
 });
 
+test('QuaternionSequence - clone', (t) => {
+	const original = new QuaternionSequence(
+		Float32Array.from([1, 2, 3]),
+		Float32Array.from([4, 5, 6]),
+		Float32Array.from([7, 8, 9]),
+		Float32Array.from([10, 11, 12]),
+		100
+	);
+
+	const cloned = original.clone();
+
+	t.not(cloned, original, 'Cloned instance should not be the same object as original');
+	t.deepEqual(Array.from(cloned.x), Array.from(original.x), 'x arrays should be equal');
+	t.deepEqual(Array.from(cloned.y), Array.from(original.y), 'y arrays should be equal');
+	t.deepEqual(Array.from(cloned.z), Array.from(original.z), 'z arrays should be equal');
+	t.deepEqual(Array.from(cloned.w), Array.from(original.w), 'w arrays should be equal');
+	t.is(cloned.frameRate, original.frameRate, 'frameRate should be equal');
+
+	// Mutate original and check clone is unaffected.
+	original.x[0] = 99;
+	t.not(cloned.x[0], original.x[0], 'Cloned x array should not be affected by changes to original');
+});
+
 test('QuaternionSequence - fromArray', (t) => {
 	const qSeq = QuaternionSequence.fromArray([fakeArray, fakeArray, fakeArray, fakeArray]);
 

--- a/src/lib/models/sequence/quaternion-sequence.ts
+++ b/src/lib/models/sequence/quaternion-sequence.ts
@@ -38,6 +38,21 @@ export class QuaternionSequence implements ISequence {
 	}
 
 	/**
+	 * Creates a clone of this quaternion sequence.
+	 * 
+	 * @returns A new QuaternionSequence with the same x, y, z, w values.
+	 */
+	clone(): QuaternionSequence {
+		return new QuaternionSequence(
+			this.x.slice(),
+			this.y.slice(),
+			this.z.slice(),
+			this.w.slice(),
+			this.frameRate
+		);
+	}
+
+	/**
 	 * Ensures that the quaternion sequence is continuous. 
 	 *
 	 * @param result The quaternion sequence to store the result in.

--- a/src/lib/models/sequence/vector-sequence.spec.ts
+++ b/src/lib/models/sequence/vector-sequence.spec.ts
@@ -18,6 +18,26 @@ test('VectorSequence - constructor', (t) => {
 	});
 });
 
+test('VectorSequence - clone', (t) => {
+	const x = Float32Array.from([1, 2, 3]);
+	const y = Float32Array.from([4, 5, 6]);
+	const z = Float32Array.from([7, 8, 9]);
+	const frameRate = 120;
+
+	const original = new VectorSequence(x, y, z, frameRate);
+	const cloned = original.clone();
+
+	t.not(cloned, original, 'Cloned instance should not be the same reference as original');
+	t.deepEqual(Array.from(cloned.x), Array.from(original.x), 'Cloned x array should match original');
+	t.deepEqual(Array.from(cloned.y), Array.from(original.y), 'Cloned y array should match original');
+	t.deepEqual(Array.from(cloned.z), Array.from(original.z), 'Cloned z array should match original');
+	t.is(cloned.frameRate, original.frameRate, 'Cloned frameRate should match original');
+
+	// Mutate original and ensure clone does not change.
+	original.x[0] = 99;
+	t.not(cloned.x[0], original.x[0], 'Cloned x array should not be affected by changes to original');
+});
+
 test('VectorSequence - cross', (t) => {
 	const x1 = Float32Array.from([1, 1, 0]);
 	const y1 = Float32Array.from([0, 0, 1]);

--- a/src/lib/models/sequence/vector-sequence.ts
+++ b/src/lib/models/sequence/vector-sequence.ts
@@ -33,6 +33,10 @@ export class VectorSequence implements ISequence {
 		this.array = [this.x, this.y, this.z];
 	}
 
+	clone(): VectorSequence {
+		return new VectorSequence(this.x.slice(), this.y.slice(), this.z.slice(), this.frameRate);
+	}
+
 	/**
 	 * Adds a vector from each vector in the current [[VectorSequence]].
 	 *

--- a/src/lib/models/signal.spec.ts
+++ b/src/lib/models/signal.spec.ts
@@ -553,7 +553,7 @@ test('Signal - convertToTargetSpace - Float32Array from a VectorSequence', (t) =
 
 	t.is(s1_vecseq3.targetSpace, undefined);
 	t.is(s1_vecseq3.space, space);
-	t.deepEqual(s1_vecseq3.getFloat32ArrayValue(), Float32Array.from([1, 2, 3]));
+	t.deepEqual(Array.from(s1_vecseq3.getFloat32ArrayValue()), [1, 2, 3]);
 });
 
 test('Signal - convertToTargetSpace - Float32Array from a Segment', (t) => {
@@ -762,10 +762,10 @@ test('Signal - clone', (t) => {
 	t.is(clone.frameRate, source.frameRate);
 	t.is(clone.set, source.set);
 	t.is(clone.space, source.space);
-	t.is(clone.targetSpace, source.targetSpace);
-	t.is(clone.cycles, source.cycles);
+	t.deepEqual(clone.targetSpace, source.targetSpace);
+	t.deepEqual(clone.cycles, source.cycles);
 	t.is(clone.resultType, source.resultType);
-	t.is(clone.getValue(), source.getValue());
+	t.deepEqual(clone.getValue(), source.getValue());
 	t.is(clone.type, source.type);
 	t.is(clone.originalSignal, source.originalSignal);
 	t.is(clone.component, source.component);
@@ -790,7 +790,7 @@ test('Signal - clone with no value', (t) => {
 	t.is(clone.set, source.set);
 	t.is(clone.space, source.space);
 	t.is(clone.targetSpace, source.targetSpace);
-	t.is(clone.cycles, source.cycles);
+	t.deepEqual(clone.cycles, source.cycles);
 	t.is(clone.resultType, source.resultType);
 
 	t.is(clone.getValue(), undefined); // Should have no value
@@ -815,7 +815,7 @@ test('Signal - clone with a new value', (t) => {
 	t.is(clone.set, source.set);
 	t.is(clone.space, source.space);
 	t.is(clone.targetSpace, source.targetSpace);
-	t.is(clone.cycles, source.cycles);
+	t.deepEqual(clone.cycles, source.cycles);
 	t.is(clone.resultType, source.resultType);
 
 	t.is(clone.getValue(), fakeArray); // Should be our new array

--- a/src/lib/models/signal.ts
+++ b/src/lib/models/signal.ts
@@ -1,6 +1,7 @@
 import { range } from 'lodash';
 
 import { Space } from '../processing/space';
+import { TypeCheck } from '../utils/type-check';
 
 import { ForcePlate } from './force-plate';
 import { Joint } from './joint';
@@ -744,11 +745,11 @@ export class Signal implements IDataSequence {
 		out.space = this.space;
 		out.targetSpace = this.targetSpace;
 		out.frameRate = this.frameRate;
-		out.cycles = this.cycles;
+		out.cycles = this.cycles ? Array.from(this.cycles) : undefined;
 		out.isEvent = this.isEvent;
 		out.originalSignal = this.originalSignal;
 		out.component = this.component;
-		out.property = this.property;
+		out.property = structuredClone(this.property);
 
 		if (this._resultType) {
 			out.resultType = this._resultType;
@@ -761,7 +762,17 @@ export class Signal implements IDataSequence {
 			}
 		}
 		else {
-			out.setValue(this.getValue(), this.frameMap);
+			const value = this.getValue();
+
+			if (TypeCheck.isArrayLike(value)) {
+				out.setValue(value.slice(), this.frameMap);
+			}
+			else if (value instanceof VectorSequence || value instanceof Segment || value instanceof Joint || value instanceof ForcePlate || value instanceof PlaneSequence) {
+				out.setValue(value.clone(), this.frameMap);
+			}
+			else if (typeof value === 'string' || typeof value === 'number') {
+				out.setValue(value, this.frameMap);
+			}
 		}
 
 		return out;

--- a/src/lib/models/spatial/matrix.ts
+++ b/src/lib/models/spatial/matrix.ts
@@ -31,6 +31,18 @@ export class Matrix {
 	}
 
 	/**
+	 * Creates a clone of this matrix.
+	 * @returns A new Matrix with the same values.
+	 */
+	clone(): Matrix {
+		const cloned = new Matrix();
+		cloned._m.set(this._m);
+		cloned.fractionDigits = this.fractionDigits;
+
+		return cloned;
+	}
+
+	/**
 	 * Copy all components from the specified matrix.
 	 * 
 	 * @param m The matrix to copy values from.

--- a/src/lib/models/spatial/vector.ts
+++ b/src/lib/models/spatial/vector.ts
@@ -91,6 +91,14 @@ export class Vector implements IVector {
 	}
 
 	/**
+	 * Creates a clone of this vector.
+	 * @returns A new Vector with the same x, y, z values.
+	 */
+	clone(): Vector {
+		return new Vector(this.x, this.y, this.z);
+	}
+
+	/**
 	 * Computes the cross product of two vectors.
 	 *
 	 * @param a The first operand.


### PR DESCRIPTION
This PR changes `Signal.clone` to copy data instead of keeping references to the original signal.

It started out as a simple quest to fix one method but ended up requiring many `clone` method implementations.

### Checklist
- [x] Test case implemented
- [ ] Test coverage 100%
- [x] Tested inside a yaml pipeline
- [ ] Documentation added

